### PR TITLE
feat: add mike cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.9.4'
       - name: Intialiaze Python Env
         run: |
           git rev-parse --abbrev-ref HEAD
@@ -83,7 +83,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.9.4'
       - name: Intialiaze Python Env
         run: |
           git rev-parse --abbrev-ref HEAD

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,120 @@
+name: build and push image
+# 3个功能,
+# 1. 默认更新 main 内容到 dev 文档
+# 2. 更新指定分支版本文档
+# 3. 根据 main 分支, 发布全新 Release 版本, 此时需要勾选 is_append_new_version 并指定 version
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Update Release Version, e.g main'
+        required: true
+        default: 'main'
+      is_append_new_version:
+        description: 'True To Deploy New Release, False To Update Exist Release'
+        required: false
+        type: boolean
+      version:
+        description: 'New Release Version, e.g 0.6, Work On True, Depend On main'
+        required: false
+        default: '0.1'
+
+jobs:
+  build-new-release:
+    if: ${{ inputs.is_append_new_version }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: checkout
+        uses: actions/checkout@v3
+        with:
+          ref: main # 一定是根据 main 分支发布最新文档, 不允许根据旧文档发布
+      - name: check branch
+        run: |
+          git status
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Intialiaze Python Env
+        run: |
+          git rev-parse --abbrev-ref HEAD
+          pip install -r requirements.txt
+      - name: Git Config
+        run: |
+          git fetch --all
+          git config --global user.email ${{ secrets.GITUSEREMAIL }}
+          git config --global user.name ${{ secrets.GITUSERNAME }}
+      - name: Mike New Release Version Snapshot
+        run: |
+          mike deploy --push --update-aliases ${{ inputs.version }} latest
+          mike set-default --push latest
+      - name: Checkout New Release Branch For Archive
+        run: |
+          git checkout -b ${{ inputs.version }}
+          git push -u origin ${{ inputs.version }}
+    
+      - name: Login Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUBUSER }}
+          password: ${{ secrets.DOCKERHUBPASSWORD }}
+
+      - name: Build && Push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            matrixorigin/matrixorigin.io.cn:${{ inputs.version }}_${{ github.sha }} #//
+            matrixorigin/matrixorigin.io.cn:latest
+
+  build-exist-release:
+    if: ${{ !inputs.is_append_new_version }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }} # 可以指定分支 checkout, 但不允许直接修改 gh-pages
+      - name: check branch
+        run: |
+          git status
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Intialiaze Python Env
+        run: |
+          git rev-parse --abbrev-ref HEAD
+          pip install -r requirements.txt
+      - name: Git Config
+        run: |
+          git fetch --all
+          git config --global user.email ${{ secrets.GITUSEREMAIL }}
+          git config --global user.name ${{ secrets.GITUSERNAME }}
+
+      - name: Mike Dev Version Snapshot
+        if: ${{ inputs.branch == 'main' }}
+        run: |
+          mike deploy --push dev
+      - name: Mike Released Version Snapshot
+        if: ${{ inputs.branch != 'main' }}
+        run: |
+          mike deploy --push ${{ inputs.branch }}
+
+      - name: Login Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUBUSER }}
+          password: ${{ secrets.DOCKERHUBPASSWORD }}
+
+      - name: Build && Push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            matrixorigin/matrixorigin.io.cn:${{ inputs.branch }}_${{ github.sha }} #//
+            matrixorigin/matrixorigin.io.cn:latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,7 +66,7 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            matrixorigin/matrixorigin.io.cn:${{ inputs.version }}_${{ github.sha }} #//
+            matrixorigin/matrixorigin.io.cn:${{ inputs.version }}_${{ github.sha }}
             matrixorigin/matrixorigin.io.cn:latest
 
   build-exist-release:
@@ -116,5 +116,5 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            matrixorigin/matrixorigin.io.cn:${{ inputs.branch }}_${{ github.sha }} #//
+            matrixorigin/matrixorigin.io.cn:${{ inputs.branch }}_${{ github.sha }}
             matrixorigin/matrixorigin.io.cn:latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,9 +22,9 @@ on:
         required: false
         type: boolean
       version:
-        description: 'New Release Version, e.g 0.6, Work On True, Depend On main'
+        description: 'New Release Version, e.g 0.6.0, Work On True, Depend On main'
         required: false
-        default: '0.1'
+        default: '0.6.0'
 
 jobs:
   build-new-release:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9.4'
+          python-version: '3.9'
       - name: Intialiaze Python Env
         run: |
           git rev-parse --abbrev-ref HEAD
@@ -90,7 +90,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9.4'
+          python-version: '3.9'
       - name: Intialiaze Python Env
         run: |
           git rev-parse --abbrev-ref HEAD

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,14 +9,6 @@ on:
       branch:
         description: 'Update Docs Version From Branch, e.g main for dev'
         required: true
-        type: choice
-        options:
-          - main
-          - '0.6.0'
-          - '0.5.1'
-          - '0.5.0'
-          - '0.4.0'
-          - '0.3.0'
         default: 'main'
       is_set_default:
         description: 'True To Set Default Version When Visited'
@@ -30,6 +22,7 @@ jobs:
       - id: checkout
         uses: actions/checkout@v3
         with:
+          token: ${{ secrets.ACTIONTOKEN }}
           ref: ${{ inputs.branch }} # 可以指定分支 checkout, 但不允许直接修改 gh-pages
       - name: branch status
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,8 +7,15 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Update Release Version, e.g main'
+        description: 'Update Released Version, e.g main'
         required: true
+        type: choice
+        options:
+          - main
+          - '0.5.1'
+          - '0.5.0'
+          - '0.4.0'
+          - '0.3.0'
         default: 'main'
       is_append_new_version:
         description: 'True To Deploy New Release, False To Update Exist Release'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,89 +2,36 @@ name: build and push image
 # 3个功能,
 # 1. 默认更新 main 内容到 dev 文档
 # 2. 更新指定分支版本文档
-# 3. 根据 main 分支, 发布全新 Release 版本, 此时需要勾选 is_append_new_version 并指定 version
+# 3. 可以设置指定版本为默认访问版本
 on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Update Released Version, e.g main'
+        description: 'Update Docs Version From Branch, e.g main for dev'
         required: true
         type: choice
         options:
           - main
+          - '0.6.0'
           - '0.5.1'
           - '0.5.0'
           - '0.4.0'
           - '0.3.0'
         default: 'main'
-      is_append_new_version:
-        description: 'True To Deploy New Release, False To Update Exist Release'
+      is_set_default:
+        description: 'True To Set Default Version When Visited'
         required: false
         type: boolean
-      version:
-        description: 'New Release Version, e.g 0.6.0, Work On True, Depend On main'
-        required: false
-        default: '0.6.0'
 
 jobs:
-  build-new-release:
-    if: ${{ inputs.is_append_new_version }}
-    runs-on: ubuntu-latest
-    steps:
-      - id: checkout
-        uses: actions/checkout@v3
-        with:
-          ref: main # 一定是根据 main 分支发布最新文档, 不允许根据旧文档发布
-      - name: check branch
-        run: |
-          git status
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-      - name: Intialiaze Python Env
-        run: |
-          git rev-parse --abbrev-ref HEAD
-          pip install -r requirements.txt
-      - name: Git Config
-        run: |
-          git fetch --all
-          git config --global user.email ${{ secrets.GITUSEREMAIL }}
-          git config --global user.name ${{ secrets.GITUSERNAME }}
-      - name: Mike New Release Version Snapshot
-        run: |
-          mike deploy --push --update-aliases ${{ inputs.version }} latest
-          mike set-default --push latest
-      - name: Checkout New Release Branch For Archive
-        run: |
-          git checkout -b ${{ inputs.version }}
-          git push -u origin ${{ inputs.version }}
-    
-      - name: Login Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUBUSER }}
-          password: ${{ secrets.DOCKERHUBPASSWORD }}
-
-      - name: Build && Push
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: |
-            matrixorigin/matrixorigin.io.cn:${{ inputs.version }}_${{ github.sha }}
-            matrixorigin/matrixorigin.io.cn:latest
-
-  build-exist-release:
-    if: ${{ !inputs.is_append_new_version }}
+  build:
     runs-on: ubuntu-latest
     steps:
       - id: checkout
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.branch }} # 可以指定分支 checkout, 但不允许直接修改 gh-pages
-      - name: check branch
+      - name: branch status
         run: |
           git status
 
@@ -101,14 +48,29 @@ jobs:
           git config --global user.email ${{ secrets.GITUSEREMAIL }}
           git config --global user.name ${{ secrets.GITUSERNAME }}
 
-      - name: Mike Dev Version Snapshot
+      - name: Mike dev Version Snapshot
         if: ${{ inputs.branch == 'main' }}
         run: |
           mike deploy --push dev
-      - name: Mike Released Version Snapshot
+      - name: Mike ${{ inputs.branch }} Version Snapshot
         if: ${{ inputs.branch != 'main' }}
         run: |
           mike deploy --push ${{ inputs.branch }}
+
+      - name: Mike Set Default Version
+        if: ${{ inputs.branch == 'main' && inputs.is_set_default }}
+        run: |
+          mike list
+          mike alias -u dev latest
+          mike list
+          mike set-default --push latest
+      - name: Mike Set Default Version
+        if: ${{ inputs.branch != 'main' && inputs.is_set_default }}
+        run: |
+          mike list
+          mike alias -u ${{ inputs.branch }} latest
+          mike list
+          mike set-default --push latest
 
       - name: Login Docker Hub
         uses: docker/login-action@v2


### PR DESCRIPTION
增加 mike cd 脚本, 支持 3 种功能
1. 更新 main 内容到 dev 版本
2. 更新指定旧版本内容
3. 根据最新 main 内容发布全新版本

目前约定 cd 脚本都是用 main 分支上的, 忽略其余分支 workflow 