### PR TITLE
Update backup-restore-matrixone-with_modump.md

### DIFF
--- a/docs/MatrixOne/Develop/export-data/backup-restore-matrixone-with_modump.md
+++ b/docs/MatrixOne/Develop/export-data/backup-restore-matrixone-with_modump.md
@@ -89,7 +89,7 @@ insert into t1 values (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, '2019-01-01', '2019-01-01 0
 将 MatrixOne 与 MySQL 客户端连接至同一服务器上，并确保导出的 *.sql* 文件也在同一服务器上。
 
 ```
-mysql> create database t if not exists;
+mysql> create database if not exists t;
 mysql> source /YOUR_SQL_FILE_PATH/t.sql
 ```
 


### PR DESCRIPTION
create database t if not exists;
SQL parser error: You have an error in your SQL syntax; check the manual that corresponds to your MatrixOne server version for the right syntax to use. syntax error at line 1 column 20 near " if not exists"; change：
create database if not exists t;