### PR TITLE
docs: fix order when get stable version to build

### DIFF
--- a/docs/MatrixOne/Get-Started/install-standalone-matrixone.md
+++ b/docs/MatrixOne/Get-Started/install-standalone-matrixone.md
@@ -84,8 +84,8 @@ __Tips__: 通过 MatrixOne 源码完成搭建时，**Linux 环境** 与 **MacOS 
 
          ```
          git clone https://github.com/matrixorigin/matrixone.git
+         cd matrixone         
          git checkout 0.6.0
-         cd matrixone
          ```
 
      2. 运行 `make config` 和 `make build` 编译文件：


### PR DESCRIPTION
We should enter the directory first then checkout to the stable version.

## What type of PR is this?

- [x] Enhancement
- [ ] Displaying
- [ ] Typo
- [ ] Doc Request

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
We should enter the directory first then checkout to the stable version.