### PR TITLE
fix MO bin package name (amd -> x86_64) in download link

### DIFF
--- a/docs/MatrixOne/Get-Started/install-on-linux/install-on-linux-method2.md
+++ b/docs/MatrixOne/Get-Started/install-on-linux/install-on-linux-method2.md
@@ -92,8 +92,9 @@ Debian11.1 版本默认没有安装 MySQL Client，因此需要手动下载安�
 
      ```bash
      mkdir -p /root/matrixone & cd /root/
-     wget https://github.com/matrixorigin/matrixone/releases/download/v1.0.0-rc1/mo-v1.0.0-rc1-linux-amd64.zip
-     unzip -d matrixone/ mo-v1.0.0-rc1-linux-amd64.zip
+     wget https://github.com/matrixorigin/matrixone/releases/download/v1.0.0-rc1/mo-v1.0.0-rc1-linux-x86_64.zip
+
+     unzip -d matrixone/ mo-v1.0.0-rc1-linux-x86_64.zip
      ```
 
      ARM 架构系统安装包：
@@ -110,8 +111,8 @@ Debian11.1 版本默认没有安装 MySQL Client，因此需要手动下载安�
 
      ```bash
      mkdir -p /root/matrixone & cd /root/
-     curl -OL https://github.com/matrixorigin/matrixone/releases/download/v1.0.0-rc1/mo-v1.0.0-rc1-linux-amd64.zip
-     unzip -d matrixone/ mo-v1.0.0-rc1-linux-amd64.zip
+     curl -OL https://github.com/matrixorigin/matrixone/releases/download/v1.0.0-rc1/mo-v1.0.0-rc1-linux-x86_64.zip
+     unzip -d matrixone/ mo-v1.0.0-rc1-linux-x86_64.zip
      ```
 
      ARM 架构系统安装包：
@@ -124,7 +125,7 @@ Debian11.1 版本默认没有安装 MySQL Client，因此需要手动下载安�
 
 === "**下载方式三：页面下载**"
 
-     如果你想通过更直观的页面下载的方式下载，直接点击进入[版本 1.0.0-rc1](https://github.com/matrixorigin/matrixone/releases/tag/v1.0.0-rc1)，下拉找到 **Assets** 栏，点击安装包 *mo-v1.0.0-rc1-linux-amd64.zip* 或者 *mo-v1.0.0-rc1-linux-arm64.zip* 下载再使用 ```unzip``` 命令解压即可。
+     如果你想通过更直观的页面下载的方式下载，直接点击进入[版本 1.0.0-rc1](https://github.com/matrixorigin/matrixone/releases/tag/v1.0.0-rc1)，下拉找到 **Assets** 栏，点击安装包 *mo-v1.0.0-rc1-linux-x86_64.zip* 或者 *mo-v1.0.0-rc1-linux-arm64.zip* 下载再使用 ```unzip``` 命令解压即可。
 
 ## 步骤 3：安装 mo_ctl 工具
 

--- a/docs/MatrixOne/Get-Started/install-on-linux/install-on-linux-method2.md
+++ b/docs/MatrixOne/Get-Started/install-on-linux/install-on-linux-method2.md
@@ -93,7 +93,6 @@ Debian11.1 版本默认没有安装 MySQL Client，因此需要手动下载安�
      ```bash
      mkdir -p /root/matrixone & cd /root/
      wget https://github.com/matrixorigin/matrixone/releases/download/v1.0.0-rc1/mo-v1.0.0-rc1-linux-x86_64.zip
-
      unzip -d matrixone/ mo-v1.0.0-rc1-linux-x86_64.zip
      ```
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] Enhancement
- [ ] Displaying
- [x] Typo
- [ ] Doc Request

## Which issue(s) this PR fixes:

issue #742

## What this PR does / why we need it:
fix the bin package name from “mo-v1.0.0-rc1-linux-amd64.zip” to "mo-v1.0.0-rc1-linux-x86_64.zip"