### PR TITLE
add a note to mo_ctl doc

### DIFF
--- a/docs/MatrixOne/FAQs/sql-faqs.md
+++ b/docs/MatrixOne/FAQs/sql-faqs.md
@@ -1,6 +1,6 @@
 # **SQL 常见问题**
 
-* **MatrixOne 兼容哪个数据库?**
+* **MatrixOne 兼容哪个数据库？**
 
 MatrixOne 在使用上保持对 MySQL 8.0 的高度兼容，包括 SQL 语法，传输协议，操作符与函数等等。与 MySQL 8.0 兼容性的差异列表可以详细参考 [MySQL 兼容性列表](../Overview/feature/mysql-compatibility.md)。
 
@@ -10,7 +10,7 @@ MatrixOne 目前支持的 SQL 语句可以参考[该详细列表](../Reference/S
 
 * **MatrixOne 支持哪些数据类型？**
 
-MatrixOne 目前支持常用的整型, 浮点数, 字符串, 时间日期, 布尔, 枚举, 二进制, JSON 类型，请参考[详细列表](../Reference/Data-Types/data-types.md)。
+MatrixOne 目前支持常用的整型，浮点数，字符串，时间日期，布尔，枚举，二进制，JSON 类型，请参考[详细列表](../Reference/Data-Types/data-types.md)。
 
 * **MatrixOne 支持什么类型的字符集？**
 
@@ -47,7 +47,7 @@ MatrixOne 的保留关键字列表可参见[该详细列表](../Reference/Langua
 
 * **如何将数据导入到 MatrixOne 中？**
 
-MatrixOne 支持与 MySQL 相同的 [`INSERT`](../Develop/import-data/insert-data.md) 数据插入语句, 可以通过 `INSERT` 进行实时数据写入，同时也支持 [`LOAD DATA`](../Develop/import-data/bulk-load/bulk-load-overview.md) 的离线批量导入语句。
+MatrixOne 支持与 MySQL 相同的 [`INSERT`](../Develop/import-data/insert-data.md) 数据插入语句，可以通过 `INSERT` 进行实时数据写入，同时也支持 [`LOAD DATA`](../Develop/import-data/bulk-load/bulk-load-overview.md) 的离线批量导入语句。
 
 * **如何将数据从 MatrixOne 导出到文件？**
 

--- a/docs/MatrixOne/Maintain/mo_ctl.md
+++ b/docs/MatrixOne/Maintain/mo_ctl.md
@@ -253,9 +253,10 @@ Usage         : mo_ctl setconf [conf_list] # set configurations
 ```
 
 !!! note
-    当set_conf的设置的路径中包含变量如`${MO_PATH}`时，需要在`$`前加上`\`，例如：
+    当 set_conf 的设置的路径中包含变量如 `${MO_PATH}` 时，需要在 `$` 前加上 `\`，例如：
     ```bash
     mo_ctl set_conf  MO_CONF_FILE="\${MO_PATH}/matrixone/etc/launch/launch.toml"
+
     ```
 
 ### get_conf - 获取参数列表

--- a/docs/MatrixOne/Maintain/mo_ctl.md
+++ b/docs/MatrixOne/Maintain/mo_ctl.md
@@ -8,32 +8,32 @@
 
 | 操作系统 | 版本                 |
 | -------- | -------------------- |
-| Debian   | 11 及以上             |
-| Ubuntu   | 20.04 及以上          |
+| Debian   | 11 及以上            |
+| Ubuntu   | 20.04 及以上         |
 | macOS    | Monterey 12.3 及以上 |
 
 `mo_ctl` 目前的功能列表如下表所示。
 
-| 命令                 | 功能                                                         |
-| -------------------- | ------------------------------------------------------------ |
-| `mo_ctl help`        | 查看`mo_ctl`工具本身的语句和功能列表                         |
-| `mo_ctl precheck`    | 检查 MatrixOne 源码安装所需要的依赖项，分别为 golang, gcc, git,MySQL Client |
-| `mo_ctl deploy`      | 下载并安装及编译 MatrixOne 相应版本，默认为安装最新稳定版本    |
-| `mo_ctl start`       | 启动 MatrixOne 服务                                            |
-| `mo_ctl status`      | 检查 MatrixOne 服务是否正在运行中                              |
-| `mo_ctl stop`        | 停止所有 MatrixOne 服务进程                                    |
-| `mo_ctl restart`       | 重启 MatrixOne 服务                                            |
-| `mo_ctl connect`     | 调用 MySQL Client 连接 MatrixOne 服务                            |
-| `mo_ctl upgrade`     | 将MatrixOne从当前版本升级/降级到某个发布版本或者commit id 版本        |
-| `mo_ctl set_conf`    | 设置各类使用参数                                             |
-| `mo_ctl get_conf`    | 查看当前使用参数                                             |
-| `mo_ctl uninstall`    | 从 MO_PATH 路径下卸载 MatrixOne                               |
-| `mo_ctl watchdog`    | 设置一个定时任务保证 MatrixOne 服务可用性，每分钟检查 MatrixOne 的状态，如果发现服务中止则自动拉起服务           |
-| `mo_ctl sql`    | 直接通过命令执行 SQL 或者 SQL 构成的文本文件           |
-| `mo_ctl ddl_convert` | 将 MySQL 的 DDL 语句转换成 MatrixOne 语句的工具                    |
-| `mo_ctl get_cid`     | 查看当前使用 MatrixOne 下载仓库的源码版本                      |
-| `mo_ctl get_branch`     | 查看当前使用 MatrixOne 下载仓库的分支版本                      |
-| `mo_ctl pprof`       | 用于收集 MatrixOne 的性能分析数据                              |
+| 命令                 | 功能                                                                                                   |
+| -------------------- | ------------------------------------------------------------------------------------------------------ |
+| `mo_ctl help`        | 查看`mo_ctl`工具本身的语句和功能列表                                                                   |
+| `mo_ctl precheck`    | 检查 MatrixOne 源码安装所需要的依赖项，分别为 golang, gcc, git,MySQL Client                            |
+| `mo_ctl deploy`      | 下载并安装及编译 MatrixOne 相应版本，默认为安装最新稳定版本                                            |
+| `mo_ctl start`       | 启动 MatrixOne 服务                                                                                    |
+| `mo_ctl status`      | 检查 MatrixOne 服务是否正在运行中                                                                      |
+| `mo_ctl stop`        | 停止所有 MatrixOne 服务进程                                                                            |
+| `mo_ctl restart`     | 重启 MatrixOne 服务                                                                                    |
+| `mo_ctl connect`     | 调用 MySQL Client 连接 MatrixOne 服务                                                                  |
+| `mo_ctl upgrade`     | 将MatrixOne从当前版本升级/降级到某个发布版本或者commit id 版本                                         |
+| `mo_ctl set_conf`    | 设置各类使用参数                                                                                       |
+| `mo_ctl get_conf`    | 查看当前使用参数                                                                                       |
+| `mo_ctl uninstall`   | 从 MO_PATH 路径下卸载 MatrixOne                                                                        |
+| `mo_ctl watchdog`    | 设置一个定时任务保证 MatrixOne 服务可用性，每分钟检查 MatrixOne 的状态，如果发现服务中止则自动拉起服务 |
+| `mo_ctl sql`         | 直接通过命令执行 SQL 或者 SQL 构成的文本文件                                                           |
+| `mo_ctl ddl_convert` | 将 MySQL 的 DDL 语句转换成 MatrixOne 语句的工具                                                        |
+| `mo_ctl get_cid`     | 查看当前使用 MatrixOne 下载仓库的源码版本                                                              |
+| `mo_ctl get_branch`  | 查看当前使用 MatrixOne 下载仓库的分支版本                                                              |
+| `mo_ctl pprof`       | 用于收集 MatrixOne 的性能分析数据                                                                      |
 
 ## 安装 mo_ctl
 
@@ -252,6 +252,12 @@ Usage         : mo_ctl setconf [conf_list] # set configurations
               : mo_ctl setconf MO_PATH=/data/mo/matrixone                                       # set single configuration
 ```
 
+!!! note
+    当set_conf的设置的路径中包含变量如`${MO_PATH}`时，需要在`$`前加上`\`，例如：
+    ```bash
+    mo_ctl set_conf  MO_CONF_FILE="\${MO_PATH}/matrixone/etc/launch/launch.toml"
+    ```
+
 ### get_conf - 获取参数列表
 
 使用 `mo_ctl get_conf [conf_list]` 获取一个或多个当前配置项。
@@ -271,27 +277,27 @@ Usage         : mo_ctl getconf [conf_list] # get configurations
 
 使用 `mo_ctl get_conf` 将打印当前工具使用的所有参数列表，它们的释义与取值范围如下表所示。
 
-| 参数名称               | 功能                                                | 取值规范                                                     |
-| ---------------------- | --------------------------------------------------- | ------------------------------------------------------------ |
-| MO_PATH                | MatrixOne 的代码库及可执行文件存放位置               | 文件夹路径                                                   |
-| MO_LOG_PATH            | MatrixOne 的日志存放位置                             | 文件夹路径，默认为${MO_PATH}/matrixone/logs                  |
-| MO_HOST                | 连接 MatrixOne 服务的 IP 地址                           | IP 地址，默认为 127.0.0.1                                      |
-| MO_PORT                | 连接 MatrixOne 服务的端口号                           | 端口号，默认为 6001                                           |
-| MO_USER                | 连接 MatrixOne 服务使用的用户名                       | 用户名，默认为 root                                           |
-| MO_PW                  | 连接 MatrixOne 服务使用的密码                         | 密码，默认为 111                                              |
-| CHECK_LIST             | precheck 需要的检查依赖项                            | 默认为 ("go" "gcc" "git" "mysql")                             |
-| GCC_VERSION            | precheck 检查的 gcc 版本                               | 默认为 8.5.0                                                  |
-| GO_VERSION             | precheck 检查的 go 版本                                | 默认为 1.20                                                   |
-| MO_GIT_URL             | MatrixOne 的源码拉取地址                             | 默认为<https://github.com/matrixorigin/matrixone.git>          |
-| MO_DEFAULT_VERSION     | 默认拉取的 MatrixOne 的版本                           | 默认为 1.0.0-rc1                                                  |
-| GOPROXY                | GOPROXY 的地址，一般为国内加速拉取 golang 依赖包而使用 | 默认为<https://goproxy.cn>,direct                              |
-| STOP_INTERVAL          | 停止间隔，停止服务后检测服务状态等待时间            | 默认为 5 秒                                                    |
-| START_INTERVAL         | 启动间隔，启动服务后检测服务状态等待时间            | 默认为 2 秒                                                    |
-| MO_DEBUG_PORT          | MatrixOne 的 debug 端口，一般为开发人员使用            | 默认为 9876                                                   |
-| MO_CONF_FILE           | MatrixOne 的启动配置文件                             | 默认为${MO_PATH}/matrixone/etc/launch/launch.toml |
-| RESTART_INTERVAL       | 重启间隔，重启服务后检测服务状态等待时间            | 默认为 2 秒                                                    |
-| PPROF_OUT_PATH         | golang 的性能收集数据输出路径                        | 默认为/tmp/pprof-test/                                       |
-| PPROF_PROFILE_DURATION | golang 的性能收集时间                                | 默认为 30 秒                                                   |
+| 参数名称               | 功能                                                   | 取值规范                                              |
+| ---------------------- | ------------------------------------------------------ | ----------------------------------------------------- |
+| MO_PATH                | MatrixOne 的代码库及可执行文件存放位置                 | 文件夹路径                                            |
+| MO_LOG_PATH            | MatrixOne 的日志存放位置                               | 文件夹路径，默认为${MO_PATH}/matrixone/logs           |
+| MO_HOST                | 连接 MatrixOne 服务的 IP 地址                          | IP 地址，默认为 127.0.0.1                             |
+| MO_PORT                | 连接 MatrixOne 服务的端口号                            | 端口号，默认为 6001                                   |
+| MO_USER                | 连接 MatrixOne 服务使用的用户名                        | 用户名，默认为 root                                   |
+| MO_PW                  | 连接 MatrixOne 服务使用的密码                          | 密码，默认为 111                                      |
+| CHECK_LIST             | precheck 需要的检查依赖项                              | 默认为 ("go" "gcc" "git" "mysql")                     |
+| GCC_VERSION            | precheck 检查的 gcc 版本                               | 默认为 8.5.0                                          |
+| GO_VERSION             | precheck 检查的 go 版本                                | 默认为 1.20                                           |
+| MO_GIT_URL             | MatrixOne 的源码拉取地址                               | 默认为<https://github.com/matrixorigin/matrixone.git> |
+| MO_DEFAULT_VERSION     | 默认拉取的 MatrixOne 的版本                            | 默认为 1.0.0-rc1                                      |
+| GOPROXY                | GOPROXY 的地址，一般为国内加速拉取 golang 依赖包而使用 | 默认为<https://goproxy.cn>,direct                     |
+| STOP_INTERVAL          | 停止间隔，停止服务后检测服务状态等待时间               | 默认为 5 秒                                           |
+| START_INTERVAL         | 启动间隔，启动服务后检测服务状态等待时间               | 默认为 2 秒                                           |
+| MO_DEBUG_PORT          | MatrixOne 的 debug 端口，一般为开发人员使用            | 默认为 9876                                           |
+| MO_CONF_FILE           | MatrixOne 的启动配置文件                               | 默认为${MO_PATH}/matrixone/etc/launch/launch.toml     |
+| RESTART_INTERVAL       | 重启间隔，重启服务后检测服务状态等待时间               | 默认为 2 秒                                           |
+| PPROF_OUT_PATH         | golang 的性能收集数据输出路径                          | 默认为/tmp/pprof-test/                                |
+| PPROF_PROFILE_DURATION | golang 的性能收集时间                                  | 默认为 30 秒                                          |
 
 ### ddl_convert - DDL 格式转换
 


### PR DESCRIPTION
## What type of PR is this?

- [x] Enhancement
- [ ] Displaying
- [ ] Typo
- [ ] Doc Request

## Which issue(s) this PR fixes:

issue :
https://github.com/matrixorigin/mo_ctl_standalone/issues/45

## What this PR does / why we need it:
mo_ctl can‘t set path containing "${MO_PATH}",users need to use '\${MO_PATH}' .

<img width="761" alt="image" src="https://github.com/matrixorigin/matrixorigin.io.cn/assets/47444607/a8c0fe27-3bad-4a2f-b582-217680a16063">
