### PR TITLE
feat(navigation): added `moc-docs` link to the navigation tabs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -597,3 +597,4 @@ nav:
         - 编码规范: MatrixOne/Contribution-Guide/Code-Style/code-of-conduct.md
         - 注释规范: MatrixOne/Contribution-Guide/Code-Style/code-comment-style.md
         - 提交规范: MatrixOne/Contribution-Guide/Code-Style/commit-pr-style.md
+  - MatrixOne Cloud: https://docs.matrixorigin.cn/zh/matrixonecloud


### PR DESCRIPTION
## What type of PR is this?

- [x] Enhancement
- [ ] Displaying
- [ ] Typo
- [ ] Doc Request

## Which issue(s) this PR fixes:

https://github.com/matrixorigin/mo-website/issues/438

## What this PR does / why we need it:

Added the link of MatrixOne Cloud docs to the navigation tabs.
 
<img width="720" alt="image" src="https://github.com/matrixorigin/matrixorigin.io.cn/assets/86586270/7f94e22a-5a59-4e48-9110-f3ff413d976b">

