### PR TITLE
[docs-sync] MatrixOne v3.0.10 文档同步 (cn)

### DIFF
--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-cn.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-cn.md
@@ -15,8 +15,19 @@
 ```
 DATA BRANCH DIFF target_table [{ SNAPSHOT = 'snapshot_name' }] 
     AGAINST base_table [{ SNAPSHOT = 'snapshot_name' }] 
+    [COLUMNS ( column_list )]
     [OUTPUT output_option]
 ```
+
+### 列投影
+
+```
+COLUMNS ( col_name [, col_name ...] )   -- 仅对列出的列进行比较
+```
+
+`COLUMNS` 会把差异比较范围缩小到指定的列。主键列始终会被包含在结果中，无论是否出现在 `column_list` 中。只有当投影列出现差异时，该行才会被标记为 `UPDATE`；投影范围外的列差异不会被计入。
+
+`COLUMNS` 不能与 `OUTPUT FILE` 同时使用。
 
 ### 输出选项
 
@@ -423,6 +434,42 @@ DROP TABLE test.orders_branch;
 -- Expected-Rows: 0
 DROP DATABASE test;
 ```
+
+### 示例 9：仅比较部分列
+
+使用 `COLUMNS` 可将比较限定到指定列，投影范围外的列差异会被忽略。
+
+```sql
+-- Expected-Rows: 0
+CREATE TABLE test.t0 (a INT PRIMARY KEY, b INT, c INT);
+-- Expected-Rows: 0
+INSERT INTO test.t0 VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3);
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE test.t1 FROM test.t0;
+-- Expected-Rows: 1
+UPDATE test.t1 SET b = 99 WHERE a = 1;
+-- Expected-Rows: 1
+UPDATE test.t1 SET c = 99 WHERE a = 2;
+
+-- 只投影 b 列，a=2 只动了 c 列，因此不会出现在结果里
+-- Expected-Rows: 2
+DATA BRANCH DIFF test.t1 AGAINST test.t0 COLUMNS (b);
++--------------------+--------+------+------+
+| diff t1 against t0 | flag   | a    | b    |
++--------------------+--------+------+------+
+| t1                 | UPDATE |    1 |   99 |
+| t0                 | UPDATE |    1 |    1 |
++--------------------+--------+------+------+
+
+-- Expected-Rows: 0
+DROP TABLE test.t0;
+-- Expected-Rows: 0
+DROP TABLE test.t1;
+```
+
+!!! note
+    `COLUMNS` 不能与 `OUTPUT FILE` 组合使用；如需对投影列限制返回量，请改用 `OUTPUT LIMIT` 或 `OUTPUT COUNT`。
 
 ## 注意事项
 

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md
@@ -1,0 +1,330 @@
+# DATA BRANCH PICK
+
+## 语法说明
+
+`DATA BRANCH PICK` 语句用于将源表中**指定的少量行**精准地合入目标表，行的范围可以通过 `KEYS`（主键值）指定，也可以通过 `BETWEEN SNAPSHOT`（快照时间窗口）指定。其作用类似于 Git 的 `cherry-pick`：不是把两个分支之间的全部差异都合进来，而是只把你明确挑选的行应用到目标表上。
+
+对于每个被选中的主键，`DATA BRANCH PICK` 会使用与 `DATA BRANCH DIFF` 相同的最近公共祖先（LCA）逻辑计算源表与目标表之间的差异，过滤出命中选中 key 的行，再把相应的 INSERT / UPDATE / DELETE 应用到目标表。
+
+## 语法结构
+
+```
+DATA BRANCH PICK source_table [{ SNAPSHOT = 'snapshot_name' }]
+    INTO destination_table
+    [ BETWEEN SNAPSHOT from_snapshot AND to_snapshot ]
+    [ KEYS ( value_list | subquery ) ]
+    [ WHEN CONFLICT conflict_option ]
+```
+
+`BETWEEN SNAPSHOT ... AND ...` 与 `KEYS (...)` 至少需要指定其中之一。
+
+### KEYS 子句
+
+```
+KEYS ( value_list )        -- 指定的主键字面量列表
+KEYS ( subquery )          -- 返回主键列的 SELECT 子查询
+```
+
+- 单列主键时，`value_list` 是逗号分隔的字面量列表，例如 `KEYS (1, 2, 3)`。
+- 复合主键时，`value_list` 是多个元组，元组内列的顺序必须与 `PRIMARY KEY` 的定义一致，例如 `KEYS ((100, 'A100'), (101, 'B200'))`。
+- 子查询必须按主键列顺序投影出所有主键列。若子查询中某个主键列为 `NULL`，语句会报错。
+
+### 冲突处理选项
+
+```
+conflict_option:
+    FAIL       -- 出现冲突即报错终止（默认）
+  | SKIP       -- 冲突行保持目标表原值不变
+  | ACCEPT     -- 冲突行用源表的值覆盖目标表
+```
+
+冲突的定义：被选中的主键在源表与目标表中都存在，但非主键列的值不同（UPDATE 冲突）；或者两端各自独立 INSERT 了相同主键但取值不同的行（INSERT 冲突）。
+
+## 语法释义
+
+| 参数 | 说明 |
+|------|------|
+| `source_table` | 源分支 / 源表，提供需要挑选的行。 |
+| `destination_table` | 接收挑选结果的目标分支 / 目标表。 |
+| `source_table` 上的 `{ SNAPSHOT = 'snapshot_name' }` | 可选：按源表在该快照时刻的数据进行挑选。 |
+| `BETWEEN SNAPSHOT from_snapshot AND to_snapshot` | 可选：只挑选源表在两个快照之间发生过变化的行，可与 `KEYS` 组合使用。 |
+| `KEYS (...)` | 需要挑选的主键集合，可以是字面量 / 元组列表，也可以是 `SELECT` 子查询。 |
+| `WHEN CONFLICT FAIL \| SKIP \| ACCEPT` | 命中 key 的行与目标表冲突时的处理方式，默认为 `FAIL`。 |
+
+## 使用说明
+
+### 使用要求与限制
+
+- **目标表必须有主键**：`destination_table` 必须定义主键，否则 `DATA BRANCH PICK` 会报错；无主键的表不能作为目标。
+- **不能在显式事务中执行**：不能在 `BEGIN ... COMMIT` 块内部调用 `DATA BRANCH PICK`。
+- **目标表不能带 SNAPSHOT**：`destination_table` 不允许使用 `{ SNAPSHOT = ... }`。
+- **`BETWEEN SNAPSHOT` 与源表快照互斥**：`BETWEEN SNAPSHOT ... AND ...` 不能与 `source_table` 上的 `{ SNAPSHOT = ... }` 同时出现。
+- **KEYS 子查询不允许 NULL**：若子查询返回的主键列值为 `NULL`，语句会报错。
+- **权限**：调用者需要对 `source_table` 有读权限，对 `destination_table` 有修改权限。
+
+### 实际执行的操作
+
+对每一个被选中的主键：
+
+- 该主键只存在于源表时，把源表的行插入目标表。
+- 该主键在两表中值完全相同，不做任何变更。
+- 该主键在两表中都存在但非主键列不同，按 `WHEN CONFLICT` 选项决定行为。
+- 该主键仅在目标表中存在，而源表相对 LCA 做过删除：`ACCEPT` 会在目标表删除该行；`SKIP` 保留该行；`FAIL` 终止执行。
+
+不在任何一侧出现的 key 视为 no-op。
+
+## 示例
+
+### 示例 1：无共同祖先时按主键挑选
+
+```sql
+-- Expected-Rows: 0
+CREATE DATABASE test;
+-- Expected-Rows: 0
+USE test;
+
+-- Expected-Rows: 0
+CREATE TABLE test.t1 (a INT PRIMARY KEY, b INT);
+-- Expected-Rows: 0
+INSERT INTO test.t1 VALUES (1, 1), (3, 3), (5, 5);
+
+-- Expected-Rows: 0
+CREATE TABLE test.t2 (a INT PRIMARY KEY, b INT);
+-- Expected-Rows: 0
+INSERT INTO test.t2 VALUES (1, 1), (2, 2), (4, 4);
+
+-- Expected-Rows: 0
+DATA BRANCH PICK test.t2 INTO test.t1 KEYS (2);
+SELECT * FROM test.t1 ORDER BY a;
++---+---+
+| a | b |
++---+---+
+| 1 | 1 |
+| 2 | 2 |
+| 3 | 3 |
+| 5 | 5 |
++---+---+
+
+-- Expected-Rows: 0
+DROP TABLE test.t1;
+-- Expected-Rows: 0
+DROP TABLE test.t2;
+```
+
+### 示例 2：有共同祖先时挑选多行
+
+```sql
+-- Expected-Rows: 0
+CREATE TABLE test.t0 (a INT PRIMARY KEY, b INT);
+-- Expected-Rows: 0
+INSERT INTO test.t0 VALUES (1, 1), (2, 2), (3, 3);
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE test.t1 FROM test.t0;
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE test.t2 FROM test.t0;
+-- Expected-Rows: 0
+INSERT INTO test.t2 VALUES (5, 5), (6, 6), (7, 7);
+
+-- 只把 t2 中 pk=5 和 pk=7 合进 t1（跳过 pk=6）
+-- Expected-Rows: 0
+DATA BRANCH PICK test.t2 INTO test.t1 KEYS (5, 7);
+SELECT * FROM test.t1 ORDER BY a;
+
+-- Expected-Rows: 0
+DROP TABLE test.t0;
+-- Expected-Rows: 0
+DROP TABLE test.t1;
+-- Expected-Rows: 0
+DROP TABLE test.t2;
+```
+
+### 示例 3：通过子查询动态指定要挑选的 key
+
+```sql
+-- Expected-Rows: 0
+CREATE TABLE test.src (a INT PRIMARY KEY, b INT);
+-- Expected-Rows: 0
+INSERT INTO test.src VALUES (1, 10), (2, 20), (3, 30), (4, 40);
+
+-- Expected-Rows: 0
+CREATE TABLE test.dst (a INT PRIMARY KEY, b INT);
+
+-- 驱动表列出需要挑选的主键
+-- Expected-Rows: 0
+CREATE TABLE test.pick_list (k INT PRIMARY KEY);
+-- Expected-Rows: 0
+INSERT INTO test.pick_list VALUES (1), (3);
+
+-- Expected-Rows: 0
+DATA BRANCH PICK test.src INTO test.dst KEYS (SELECT k FROM test.pick_list);
+SELECT * FROM test.dst ORDER BY a;
+
+-- Expected-Rows: 0
+DROP TABLE test.src;
+-- Expected-Rows: 0
+DROP TABLE test.dst;
+-- Expected-Rows: 0
+DROP TABLE test.pick_list;
+```
+
+### 示例 4：冲突处理 FAIL / SKIP / ACCEPT
+
+```sql
+-- Expected-Rows: 0
+CREATE TABLE test.t0 (a INT PRIMARY KEY, b INT);
+-- Expected-Rows: 0
+INSERT INTO test.t0 VALUES (1, 1), (2, 2);
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE test.t1 FROM test.t0;
+-- Expected-Rows: 0
+INSERT INTO test.t1 VALUES (3, 30);
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE test.t2 FROM test.t0;
+-- Expected-Rows: 0
+INSERT INTO test.t2 VALUES (3, 40);
+
+-- 默认 FAIL：两端都插入了 pk=3 但值不同，直接报错
+-- Expected-Success: false
+DATA BRANCH PICK test.t2 INTO test.t1 KEYS (3);
+
+-- SKIP：保留 t1 的值（b = 30）
+-- Expected-Rows: 0
+DATA BRANCH PICK test.t2 INTO test.t1 KEYS (3) WHEN CONFLICT SKIP;
+
+-- ACCEPT：覆盖为 t2 的值（b = 40）
+-- Expected-Rows: 0
+DATA BRANCH PICK test.t2 INTO test.t1 KEYS (3) WHEN CONFLICT ACCEPT;
+
+-- Expected-Rows: 0
+DROP TABLE test.t0;
+-- Expected-Rows: 0
+DROP TABLE test.t1;
+-- Expected-Rows: 0
+DROP TABLE test.t2;
+```
+
+### 示例 5：从源表快照挑选
+
+```sql
+-- Expected-Rows: 0
+CREATE TABLE test.t0 (a INT PRIMARY KEY, b INT);
+-- Expected-Rows: 0
+INSERT INTO test.t0 VALUES (1, 1), (2, 2), (3, 3);
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE test.t1 FROM test.t0;
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE test.t2 FROM test.t0;
+-- Expected-Rows: 0
+INSERT INTO test.t2 VALUES (4, 4), (5, 5);
+
+-- 冻结 t2 的状态，然后继续修改
+-- Expected-Rows: 0
+CREATE SNAPSHOT sp_src FOR ACCOUNT sys;
+-- Expected-Rows: 1
+UPDATE test.t2 SET b = 50 WHERE a = 5;
+-- Expected-Rows: 0
+INSERT INTO test.t2 VALUES (6, 6);
+
+-- 从冻结视图挑选：pk=5 会取快照值 b=5，而不是 50；
+-- 快照时刻尚不存在 pk=6，因此对它的 PICK 视为 no-op。
+-- Expected-Rows: 0
+DATA BRANCH PICK test.t2 {SNAPSHOT='sp_src'} INTO test.t1 KEYS (4, 5, 6);
+SELECT * FROM test.t1 ORDER BY a;
+
+-- Expected-Rows: 0
+DROP SNAPSHOT sp_src;
+-- Expected-Rows: 0
+DROP TABLE test.t0;
+-- Expected-Rows: 0
+DROP TABLE test.t1;
+-- Expected-Rows: 0
+DROP TABLE test.t2;
+```
+
+### 示例 6：按快照时间窗口挑选变更
+
+```sql
+-- Expected-Rows: 0
+CREATE TABLE test.t0 (a INT PRIMARY KEY, b INT);
+-- Expected-Rows: 0
+INSERT INTO test.t0 VALUES (1, 1);
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE test.t1 FROM test.t0;
+
+-- Expected-Rows: 0
+CREATE SNAPSHOT sp_from FOR ACCOUNT sys;
+-- Expected-Rows: 0
+INSERT INTO test.t1 VALUES (2, 2), (3, 3);
+-- Expected-Rows: 0
+CREATE SNAPSHOT sp_to FOR ACCOUNT sys;
+-- Expected-Rows: 0
+INSERT INTO test.t1 VALUES (4, 4);
+
+-- Expected-Rows: 0
+CREATE TABLE test.t2 (a INT PRIMARY KEY, b INT);
+
+-- 只挑选 sp_from 到 sp_to 之间发生过变化的行（pk=2、pk=3；pk=4 不在窗口内）
+-- Expected-Rows: 0
+DATA BRANCH PICK test.t1 INTO test.t2 BETWEEN SNAPSHOT sp_from AND sp_to;
+SELECT * FROM test.t2 ORDER BY a;
+
+-- Expected-Rows: 0
+DROP SNAPSHOT sp_from;
+-- Expected-Rows: 0
+DROP SNAPSHOT sp_to;
+-- Expected-Rows: 0
+DROP TABLE test.t0;
+-- Expected-Rows: 0
+DROP TABLE test.t1;
+-- Expected-Rows: 0
+DROP TABLE test.t2;
+```
+
+### 示例 7：复合主键
+
+```sql
+-- Expected-Rows: 0
+CREATE TABLE test.orders (
+    tenant_id  INT,
+    order_code VARCHAR(8),
+    amount     DECIMAL(12, 2),
+    PRIMARY KEY (tenant_id, order_code)
+);
+-- Expected-Rows: 0
+INSERT INTO test.orders VALUES
+    (100, 'A100', 120.50),
+    (100, 'A101',  80.00),
+    (101, 'B200', 305.75);
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE test.orders_branch FROM test.orders;
+-- Expected-Rows: 0
+INSERT INTO test.orders_branch VALUES
+    (102, 'C300', 512.25),
+    (103, 'D400',  42.00);
+
+-- 只挑选 (102, 'C300')
+-- Expected-Rows: 0
+DATA BRANCH PICK test.orders_branch INTO test.orders
+    KEYS ((102, 'C300'));
+SELECT * FROM test.orders ORDER BY tenant_id, order_code;
+
+-- Expected-Rows: 0
+DROP TABLE test.orders;
+-- Expected-Rows: 0
+DROP TABLE test.orders_branch;
+```
+
+## 注意事项
+
+1. **与 `DATA BRANCH MERGE` 的区别**：`MERGE` 会应用两个分支之间的全部差异，`PICK` 只应用你在 `KEYS` 中列出的主键集合，或 `BETWEEN SNAPSHOT` 窗口内变化的行。
+2. **默认冲突策略是 `FAIL`**：如果希望忽略冲突或直接覆盖，请显式指定 `WHEN CONFLICT SKIP` 或 `WHEN CONFLICT ACCEPT`。
+3. **表结构一致性**：`source_table` 与 `destination_table` 的列定义必须一致（与 `DATA BRANCH DIFF` / `DATA BRANCH MERGE` 的要求相同）。
+4. **隐式事务**：由于 `DATA BRANCH PICK` 不能在显式事务中执行，使用时请把它单独作为一条语句运行，不要包在 `BEGIN ... COMMIT` 内部。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -363,6 +363,7 @@ nav:
           - DELETE BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-delete-cn.md
           - DIFF BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-cn.md
           - MERGE BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-merge-cn.md
+          - PICK BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md
           - ALTER TABLE: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-table.md
           - ALTER TABLE ... ALTER REINDEX: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-reindex.md
           - ALTER PITR: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-pitr.md


### PR DESCRIPTION
# MatrixOne 文档自动同步 (cn)

## 基本信息

- Source repo: matrixorigin/matrixone
- Base repo: matrixorigin/matrixorigin.io.cn
- Head: ULookup:docs-sync/matrixone-v3.0.10 (from fork ULookup/matrixorigin.io.cn)
- Docs key: cn
- From tag: v3.0.9
- To tag: v3.0.10
- Target branch: main
- Generated by: MatrixOne Docs Sync Agent

## Tags

- From: v3.0.9
- To: v3.0.10

## User-visible Changes

本次 v3.0.9 → v3.0.10 的源码 diff 中，仅有两项可直接落到用户 SQL 参考文档的
变更：

1. **新增 `DATA BRANCH PICK` 语句**：按主键（`KEYS`）或快照窗口
   （`BETWEEN SNAPSHOT ... AND ...`）将源表中指定的行 cherry-pick 到目标表，
   支持 `WHEN CONFLICT FAIL | SKIP | ACCEPT` 三种冲突处理策略。
   - 源码证据：`pkg/sql/parsers/dialect/mysql/mysql_sql.y` 新增 `PICK` token
     以及 `DATA BRANCH PICK table_name INTO table_name
     [BETWEEN SNAPSHOT ... AND ...] [KEYS (...)] [WHEN CONFLICT ...]` 语法；
     `pkg/sql/parsers/tree/data_branch.go` 新增 `DataBranchPick` / `PickKeys`；
     `pkg/frontend/data_branch_pick.go` 的 `handleBranchPick` 在显式事务、
     目标表无主键、缺少 `KEYS`/`BETWEEN SNAPSHOT`、目标表带 SNAPSHOT 等场景
     均返回明确错误。
   - 测试证据：`test/distributed/cases/git4data/branch/pick/pick_*.sql` 覆盖
     KEYS、KEYS 子查询、复合主键、BETWEEN SNAPSHOT、FAIL/SKIP/ACCEPT 等用法。

2. **`DATA BRANCH DIFF` 新增 `COLUMNS` 投影**：允许在 `AGAINST base_table`
   之后指定 `COLUMNS (col, ...)`，只比较投影列，并且明确禁止与 `OUTPUT FILE`
   同时使用。
   - 源码证据：`pkg/sql/parsers/dialect/mysql/mysql_sql.y` 新增
     `diff_columns_opt`；`pkg/sql/parsers/tree/data_branch.go` 在
     `DataBranchDiff` 上新增 `Columns IdentifierList` 字段；运行时存在
     错误 `DATA BRANCH DIFF COLUMNS is not supported with OUTPUT FILE`。
   - 测试证据：`TestDataBranchDiffColumns` 覆盖 `columns (id, name)`、
     `columns (a, b, c) output limit 10`、`columns (x) output file '/tmp/'`
     等多种写法。

两仓的 Release Notes (`v26.3.0.10.md`) 已由上游预先提交到仓内，本次同步
保持原有 Release Notes 内容不变，仅按仓补齐 `DATA BRANCH PICK` 专页和
`DATA BRANCH DIFF` 的 `COLUMNS` 投影说明。

除上述两项之外，v3.0.10 还包含 SQL Task（`CREATE TASK` / `ALTER TASK` /
`SHOW TASKS` / `SHOW TASK RUNS` / `EXECUTE TASK` 等）以及
`ALTER ROLE ... ADD/DROP RULE` + `SHOW RULES ON ROLE` 这两组较大的新功能，
以及一批内部修复。这些变更的语义和外观超出 diff 所能单独确认的范围，已在
各仓 Skipped Changes 中标注，需要由人工主导补写专题文档；详见下文 Skipped
Changes 章节。

## Repo: cn (matrixorigin/matrixorigin.io.cn) [push: ULookup/matrixorigin.io.cn]

### Docs Updated

- `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-cn.md`
  - 语法结构块增加 `[COLUMNS ( column_list )]`。
  - 新增 `列投影` 小节，说明语义与和 `OUTPUT FILE` 的互斥关系。
  - 新增 `示例 9：仅比较部分列`。

### Docs Added

- `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md`
  - 简体中文正文，覆盖语法、`KEYS`（字面量 / 子查询）、`BETWEEN SNAPSHOT`、
    `WHEN CONFLICT FAIL | SKIP | ACCEPT`、权限 / 主键 / 显式事务限制，以及
    7 个示例（与 io 仓结构对齐，但正文、标题、示例说明均为中文；SQL 关键字、
    函数名、配置项保留英文原文）。
  - 采用中性英文文件名 `data-branch-pick.md`（cn 仓历史上 data-branch-*
    文件使用 `-cn` 后缀，但按 update-docs 提示词要求，新增文件不再带语言
    后缀；已在导航入口文本 `PICK BRANCH` 层面与其他 data branch 条目保持
    视觉一致）。

### Navigation Updated

- `mkdocs.yml`：在现有 `DIFF BRANCH` / `MERGE BRANCH` 条目之后新增
  `PICK BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md`
  入口；未改动其他导航项。

### Release Notes

- 仓内已存在 `docs/MatrixOne/Release-Notes/v26.3.0.10.md`（简体中文，风格与
  历史版本一致），其内容已涵盖本次 diff 的用户可见改动。
- 本次同步 **未修改** Release Notes 文件；文件命名沿用仓内 `v26.3.0.10.md`
  约定。

### Skipped Changes

#### Skipped: SQL Task 调度（CREATE / ALTER / DROP / SHOW TASK / SHOW TASK RUNS / EXECUTE TASK）

- Repo: cn
- Source files: 同 io 仓（见上）。
- Reason: 与 io 仓相同——该子系统涉及 parser、frontend、taskservice、
  storage 和新内部表（`mo_task.sql_task` / `sql_task_run`），仅凭 diff 无法
  稳妥写出用户面向的中文参考文档。
- Suggested human action: 由产品 / 内核团队主导，在
  `docs/MatrixOne/Reference/SQL-Reference/` 下规划 Task 专题并同步到 cn 仓。

#### Skipped: ALTER ROLE ... ADD/DROP RULE 与 SHOW RULES ON ROLE

- Repo: cn
- Source files: 同 io 仓（见上）。
- Reason: rewrite rule 的语义需要权限 / 安全团队定义（规则触发条件、优先级、
  与 GRANT 的组合关系、租户内外可见范围），diff 不足以提供稳妥中文描述。
- Suggested human action: 在 `docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/`
  新增 `ALTER ROLE`（扩展章节）与 `SHOW RULES ON ROLE`，并在《权限管理》
  章节交叉引用。

#### Skipped: 3.0.1 / 3.0.2 内部升级记录

- Repo: cn
- Source files: 同 io 仓。
- Reason: 升级框架内部行为，对用户语义没有独立影响；已被 Release Notes 中
  "统计信息视图升级" / "角色规则" / "SQL 任务流水线" 三项间接覆盖。
- Suggested human action: 不新增专门中文参考页，仅保留 Release Notes 中的
  提示。

### Risks

- **PICK 示例未实际执行**：新增的 `data-branch-pick.md` 示例基于 diff 与
  `test/distributed/cases/git4data/branch/pick/` 下测试用例推断，审阅时请让
  熟悉 data branch 的工程师核对。
- **文件名与 cn 仓历史不一致**：新增文件 `data-branch-pick.md` 未使用 `-cn`
  后缀，而历史 data-branch 文件名带 `-cn`。这是按 update-docs 提示词中
  "新增文档命名：使用中性英文文件名，不要在文件名上加 -en / -cn / -zh 等
  语言后缀" 做的一致性调整；导航入口文本按 cn 仓习惯保持 `PICK BRANCH`。
  若仓内规范要求与邻近文件命名对齐，可在评审中由维护者改名为
  `data-branch-pick-cn.md`（同时更新 `mkdocs.yml` 中的路径）。
- **Release Notes 不在本次修改范围内**：仓内已存在 `v26.3.0.10.md` 被视为
  上游既有产物，agent 未改动。
