### PR TITLE
[docs-sync] MatrixOne v3.0.10 文档同步 (cn)

### DIFF
--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-cn.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-cn.md
@@ -15,6 +15,7 @@
 ```
 DATA BRANCH DIFF target_table [{ SNAPSHOT = 'snapshot_name' }] 
     AGAINST base_table [{ SNAPSHOT = 'snapshot_name' }] 
+    [COLUMNS (col_name [, col_name ...])]
     [OUTPUT output_option]
 ```
 
@@ -24,9 +25,20 @@ DATA BRANCH DIFF target_table [{ SNAPSHOT = 'snapshot_name' }]
 output_option:
     COUNT                           -- 仅返回差异行数
   | LIMIT number                    -- 限制返回的差异行数
+  | SUMMARY                         -- 返回差异摘要（按 INSERT/DELETE/UPDATE 聚合）
   | FILE 'directory_path'           -- 将差异导出为 SQL 文件
   | AS table_name                   -- 将差异保存到表中（暂不支持）
 ```
+
+### COLUMNS 列投影
+
+`COLUMNS (...)` 用于把差异输出限制在指定列上。列名匹配大小写不敏感，
+列表中的重复项会自动去重。不写 `COLUMNS` 时，diff 会返回所有可见列，
+与之前的行为一致。
+
+`COLUMNS` 可以与 `OUTPUT LIMIT`、`OUTPUT COUNT`、`OUTPUT SUMMARY` 同时
+使用；计数和摘要的结果不受列投影影响（它们描述的是差异行数，而不是
+呈现哪些列）。
 
 ## 语法释义
 
@@ -37,8 +49,10 @@ output_option:
 | `target_table` | 目标表（要比较的表） |
 | `base_table` | 基准表（作为比较基准的表） |
 | `SNAPSHOT = 'snapshot_name'` | 可选参数，指定使用某个快照时刻的数据进行比较 |
+| `COLUMNS (col_name, ...)` | 可选。仅投影指定的列。列名大小写不敏感，重复项自动去重。不影响 `OUTPUT COUNT` / `OUTPUT SUMMARY` 的结果。 |
 | `OUTPUT COUNT` | 仅返回差异的行数统计 |
 | `OUTPUT LIMIT number` | 限制返回的差异行数 |
+| `OUTPUT SUMMARY` | 返回差异摘要，代替返回具体差异行 |
 | `OUTPUT FILE 'path'` | 将差异导出为 SQL 文件到指定目录，支持本地路径或 Stage 路径（如 `stage://stage_name/`） |
 
 ### 输出列说明
@@ -422,6 +436,69 @@ DROP TABLE test.orders;
 DROP TABLE test.orders_branch;
 -- Expected-Rows: 0
 DROP DATABASE test;
+```
+
+### 示例 9：列投影（COLUMNS）
+
+使用 `COLUMNS` 将差异输出限制到指定列。该投影不会改变差异行的集合，
+只影响每一行显示哪些列。
+
+```sql
+-- Expected-Rows: 0
+CREATE DATABASE test_diff_columns;
+-- Expected-Rows: 0
+USE test_diff_columns;
+
+-- Expected-Rows: 0
+CREATE TABLE c1(
+    id INT PRIMARY KEY,
+    name VARCHAR(30),
+    balance DECIMAL(12,2),
+    created_at TIMESTAMP,
+    birthday DATE
+);
+-- Expected-Rows: 0
+INSERT INTO c1 VALUES
+    (1, 'alice', 1000.50, '2024-01-01 10:00:00', '1990-03-15'),
+    (2, 'bob',   2000.75, '2024-01-02 11:00:00', '1985-07-20'),
+    (3, 'carol', 3000.00, '2024-01-03 12:00:00', '1992-11-08');
+
+-- Expected-Rows: 0
+CREATE SNAPSHOT c1_sp0 FOR TABLE test_diff_columns c1;
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE c1_br FROM c1{SNAPSHOT="c1_sp0"};
+-- Expected-Rows: 1
+UPDATE c1_br SET balance = 1500.50, name = 'alice_v2' WHERE id = 1;
+-- Expected-Rows: 1
+DELETE FROM c1_br WHERE id = 2;
+-- Expected-Rows: 0
+INSERT INTO c1_br VALUES (4, 'dave', 4000.00, '2024-02-01 09:00:00', '1988-12-25');
+
+-- 仅投影 name 与 balance 两列
+DATA BRANCH DIFF c1_br AGAINST c1{SNAPSHOT="c1_sp0"} COLUMNS (name, balance);
+
+-- COLUMNS + OUTPUT COUNT：计数不受投影影响
+DATA BRANCH DIFF c1_br AGAINST c1{SNAPSHOT="c1_sp0"} COLUMNS (name) OUTPUT COUNT;
+
+-- Expected-Rows: 0
+DROP SNAPSHOT c1_sp0;
+-- Expected-Rows: 0
+DROP TABLE c1;
+-- Expected-Rows: 0
+DROP TABLE c1_br;
+-- Expected-Rows: 0
+DROP DATABASE test_diff_columns;
+```
+
+### 示例 10：差异摘要（OUTPUT SUMMARY）
+
+`OUTPUT SUMMARY` 返回差异的聚合信息，而不是逐行返回差异数据。
+在需要快速了解两个分支差异规模、但不想物化完整结果集时使用。
+
+```sql
+-- Expected-Success: true
+DATA BRANCH DIFF c1_br AGAINST c1{SNAPSHOT="c1_sp0"} OUTPUT SUMMARY;
 ```
 
 ## 注意事项

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick-cn.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick-cn.md
@@ -1,0 +1,283 @@
+# DATA BRANCH PICK
+
+## 语法说明
+
+`DATA BRANCH PICK` 语句用于把源分支表中**指定的若干行** cherry-pick
+到目标分支表。与会把两个分支之间所有差异整体应用的 `DATA BRANCH MERGE`
+不同，`PICK` 只应用用户选择的行——可以通过列出主键（`KEYS`）来选择，
+也可以通过快照区间（`BETWEEN SNAPSHOT`）来限定。
+
+`DATA BRANCH PICK` 复用 `DATA BRANCH DIFF` / `DATA BRANCH MERGE` 使用的
+差异管道：系统会自动识别两个表之间的最近公共祖先（LCA，Lowest Common
+Ancestor），计算出 KEYS 指定主键所对应的有效 INSERT / DELETE / UPDATE
+集合，然后按照指定的冲突策略应用到目标表。
+
+## 语法结构
+
+```
+DATA BRANCH PICK source_table INTO destination_table
+    KEYS ( key_list | select_stmt )
+    [WHEN CONFLICT conflict_option]
+
+DATA BRANCH PICK source_table INTO destination_table
+    BETWEEN SNAPSHOT from_snapshot AND to_snapshot
+    [KEYS ( key_list | select_stmt )]
+    [WHEN CONFLICT conflict_option]
+```
+
+### KEYS 子句
+
+```
+KEYS ( expr [, expr ...] )          -- 字面主键值列表
+KEYS ( select_stmt )                -- 返回主键行的子查询
+```
+
+对于复合主键，字面 key 必须写成与主键列顺序一致的 tuple；子查询必须
+返回与主键列数一致的列。
+
+### BETWEEN SNAPSHOT 子句
+
+```
+BETWEEN SNAPSHOT snapshot_name AND snapshot_name
+```
+
+快照名既可以写成标识符，也可以写成带引号的字符串字面量。该区间用于
+限定源侧要 pick 的行所在的时间窗口。
+
+### 冲突处理选项
+
+```
+conflict_option:
+    FAIL                            -- 遇到冲突时报错并终止（默认行为）
+  | SKIP                            -- 跳过冲突的行，保留目标表的数据
+  | ACCEPT                          -- 接受源表的数据，覆盖目标表的冲突数据
+```
+
+## 语法释义
+
+| 参数 | 说明 |
+|------|------|
+| `source_table` | 源分支表。可以带 `{SNAPSHOT = 'snapshot_name'}` 选项，把源端定位到某个快照。 |
+| `destination_table` | 目标分支表。目标表**不支持**快照选项。 |
+| `KEYS ( key_list )` | 字面主键值。单列主键使用标量值；复合主键使用 tuple `(v1, v2, ...)`。 |
+| `KEYS ( select_stmt )` | 返回主键列的子查询。单列主键要求子查询返回 1 列；复合主键要求子查询按顺序返回全部主键列。 |
+| `BETWEEN SNAPSHOT from_snapshot AND to_snapshot` | 限定只挑选源端在两个快照之间发生的变更。可与 `KEYS` 组合，只挑选同时在该 KEYS 集合中的行。 |
+| `WHEN CONFLICT FAIL` | 默认值。若被 pick 的行与目标表冲突，立即报错。 |
+| `WHEN CONFLICT SKIP` | 保留目标表中冲突键的原值。 |
+| `WHEN CONFLICT ACCEPT` | 使用源表值覆盖目标表中的冲突值。 |
+
+### 冲突的定义
+
+当被 pick 的主键在两个分支上**同时存在且取值不同**时，会被判定为
+冲突。例如：两个分支都插入了相同主键但不同列值的行；或两个分支都
+更新了同一主键但结果不同；或一侧删除、另一侧更新同一主键。
+
+## 使用说明
+
+- `DATA BRANCH PICK` **不支持** 显式事务（`BEGIN ... COMMIT` 内）。
+  必须在自动提交模式下执行。
+- 语句必须至少带 `KEYS` 或 `BETWEEN SNAPSHOT` 其一，两者都缺失会报错。
+- `BETWEEN SNAPSHOT` 不能与源表的 `{SNAPSHOT = ...}` 选项同时使用。
+- 目标表不支持 `{SNAPSHOT = ...}` 选项，写了会被拒绝。
+- 子查询返回的主键列不允许出现 `NULL`。
+- 未显式指定 `WHEN CONFLICT` 时，默认行为是 `WHEN CONFLICT FAIL`。
+- 权限：执行者需要具备读取源表以及修改目标表所需的权限。
+
+## 示例
+
+### 示例 1：按主键 pick
+
+从一个分支中挑一行到另一个分支。
+
+```sql
+CREATE DATABASE test;
+USE test;
+
+CREATE TABLE t1 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t1 VALUES (1,1),(3,3),(5,5);
+
+CREATE TABLE t2 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t2 VALUES (1,1),(2,2),(4,4);
+
+DATA BRANCH PICK t2 INTO t1 KEYS(2);
+SELECT * FROM t1 ORDER BY a;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    2 |    2 |
+|    3 |    3 |
+|    5 |    5 |
++------+------+
+
+DATA BRANCH PICK t2 INTO t1 KEYS(4);
+SELECT * FROM t1 ORDER BY a;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    2 |    2 |
+|    3 |    3 |
+|    4 |    4 |
+|    5 |    5 |
++------+------+
+
+DROP TABLE t1;
+DROP TABLE t2;
+```
+
+### 示例 2：带冲突处理的 pick
+
+两个分支都插入了相同主键但不同的列值。默认的 `WHEN CONFLICT FAIL`
+会直接报错；`WHEN CONFLICT SKIP` 会保留目标表原值；
+`WHEN CONFLICT ACCEPT` 会用源表值覆盖。
+
+```sql
+CREATE TABLE t0 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t0 VALUES (1,1),(2,2);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+INSERT INTO t1 VALUES (3,30);
+
+DATA BRANCH CREATE TABLE t2 FROM t0;
+INSERT INTO t2 VALUES (3,40);
+
+-- 默认 FAIL：以下语句会报错
+DATA BRANCH PICK t2 INTO t1 KEYS(3);
+
+DATA BRANCH PICK t2 INTO t1 KEYS(3) WHEN CONFLICT SKIP;
+SELECT * FROM t1 ORDER BY a;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    2 |    2 |
+|    3 |   30 |
++------+------+
+
+DATA BRANCH PICK t2 INTO t1 KEYS(3) WHEN CONFLICT ACCEPT;
+SELECT * FROM t1 ORDER BY a;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    2 |    2 |
+|    3 |   40 |
++------+------+
+
+DROP TABLE t0;
+DROP TABLE t1;
+DROP TABLE t2;
+```
+
+### 示例 3：使用子查询驱动 KEYS（复合主键）
+
+用子查询提供要 pick 的主键集合。对于复合主键，子查询必须按顺序返回
+全部主键列。
+
+```sql
+CREATE TABLE t0 (a INT, b INT, c VARCHAR(20), PRIMARY KEY(a, b));
+INSERT INTO t0 VALUES (1,1,'base'),(2,2,'base');
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+DATA BRANCH CREATE TABLE t2 FROM t0;
+
+INSERT INTO t2 VALUES (3,3,'new'),(4,4,'new'),(5,5,'new'),(6,6,'new');
+
+DATA BRANCH PICK t2 INTO t1
+    KEYS(SELECT a, b FROM t2 WHERE a >= 4 AND a % 2 = 0);
+
+SELECT * FROM t1 ORDER BY a, b;
++------+------+------+
+| a    | b    | c    |
++------+------+------+
+|    1 |    1 | base |
+|    2 |    2 | base |
+|    4 |    4 | new  |
+|    6 |    6 | new  |
++------+------+------+
+
+DROP TABLE t0;
+DROP TABLE t1;
+DROP TABLE t2;
+```
+
+### 示例 4：按快照区间 pick
+
+`BETWEEN SNAPSHOT` 把 pick 限定在源端两个快照之间发生的变更。快照名
+可以是标识符，也可以是字符串字面量。
+
+```sql
+CREATE TABLE t0 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t0 VALUES (1,1);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+
+CREATE SNAPSHOT sp_from FOR ACCOUNT sys;
+INSERT INTO t1 VALUES (2,2),(3,3);
+CREATE SNAPSHOT sp_to FOR ACCOUNT sys;
+INSERT INTO t1 VALUES (4,4);
+
+-- 仅 pick sp_from 与 sp_to 之间 t1 上新增的行
+DATA BRANCH PICK t1 INTO t0 BETWEEN SNAPSHOT 'sp_from' AND 'sp_to';
+SELECT * FROM t0 ORDER BY a;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    2 |    2 |
+|    3 |    3 |
++------+------+
+
+DROP SNAPSHOT sp_from;
+DROP SNAPSHOT sp_to;
+DROP TABLE t0;
+DROP TABLE t1;
+```
+
+### 示例 5：BETWEEN SNAPSHOT 与 KEYS 组合
+
+`BETWEEN SNAPSHOT` 与 `KEYS` 可以一起使用，只挑选快照区间内、
+主键同时在 KEYS 集合中的行。
+
+```sql
+CREATE TABLE t0 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t0 VALUES (1,1),(2,2),(3,3);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+
+CREATE SNAPSHOT sp1 FOR ACCOUNT sys;
+INSERT INTO t1 VALUES (4,4),(5,5),(6,6);
+CREATE SNAPSHOT sp2 FOR ACCOUNT sys;
+INSERT INTO t1 VALUES (7,7);
+
+-- sp1~sp2 之间新增了 {4,5,6}，其中只 pick pk=5
+DATA BRANCH PICK t1 INTO t0 BETWEEN SNAPSHOT 'sp1' AND 'sp2' KEYS(5);
+SELECT * FROM t0 ORDER BY a;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    2 |    2 |
+|    3 |    3 |
+|    5 |    5 |
++------+------+
+
+DROP SNAPSHOT sp1;
+DROP SNAPSHOT sp2;
+DROP TABLE t0;
+DROP TABLE t1;
+```
+
+## 注意事项
+
+1. **必须带 KEYS 或 BETWEEN SNAPSHOT**：二者都缺失会被拒绝。
+2. **不支持显式事务**：`DATA BRANCH PICK` 必须在自动提交模式下执行，
+   位于 `BEGIN ... COMMIT` 内会被拒绝。
+3. **源端快照与 BETWEEN SNAPSHOT 互斥**：不能同时给源表加
+   `{SNAPSHOT = ...}` 和 `BETWEEN SNAPSHOT`。
+4. **目标表不支持快照选项**：目标表必须指向实时表，带
+   `{SNAPSHOT = ...}` 会被拒绝。
+5. **主键不允许为 NULL**：子查询返回主键列值为 `NULL` 时会报错。
+6. **默认冲突策略为 FAIL**：若需非失败行为，请显式写
+   `WHEN CONFLICT SKIP` 或 `WHEN CONFLICT ACCEPT`。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -363,6 +363,7 @@ nav:
           - DELETE BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-delete-cn.md
           - DIFF BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-cn.md
           - MERGE BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-merge-cn.md
+          - PICK BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick-cn.md
           - ALTER TABLE: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-table.md
           - ALTER TABLE ... ALTER REINDEX: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-reindex.md
           - ALTER PITR: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-pitr.md


### PR DESCRIPTION
# MatrixOne 文档自动同步 (cn)

## 基本信息

- Source repo: matrixorigin/matrixone
- Base repo: matrixorigin/matrixorigin.io.cn
- Head: ULookup:docs-sync/matrixone-v3.0.10 (from fork ULookup/matrixorigin.io.cn)
- Docs key: cn
- From tag: v3.0.9
- To tag: v3.0.10
- Target branch: main
- Generated by: MatrixOne Docs Sync Agent

## Tags

- From: v3.0.9
- To: v3.0.10

## User-visible Changes

本次同步覆盖以下用户可见变更（两个文档仓共享；语言按仓区分）：

1. **新语句 `DATA BRANCH PICK`**：支持按主键 cherry-pick 行或按
   `BETWEEN SNAPSHOT` 快照区间挑选源端变更到目标分支表，支持
   `WHEN CONFLICT FAIL|SKIP|ACCEPT` 三种冲突策略；不支持显式事务；
   不支持目标表快照选项；`BETWEEN SNAPSHOT` 与源表快照选项互斥；
   子查询 KEYS 不允许 NULL 主键列。源码证据：
   `pkg/frontend/data_branch_pick.go`、
   `pkg/sql/parsers/dialect/mysql/mysql_sql.y`（`DATA BRANCH PICK ...`
   产生式）、`test/distributed/cases/git4data/branch/pick/pick_1..12.sql`。

2. **`DATA BRANCH DIFF` 新增 `COLUMNS` 投影**：在 `AGAINST base_table`
   之后、`OUTPUT` 之前可加 `COLUMNS (col [, col ...])`，仅投影指定列；
   大小写不敏感、去重；不影响 `OUTPUT COUNT` / `OUTPUT SUMMARY`。
   证据：`pkg/sql/parsers/dialect/mysql/mysql_sql.y`（`diff_columns_opt`）、
   `test/distributed/cases/git4data/branch/diff/diff_11.sql`。

3. **`DATA BRANCH DIFF` 新增 `OUTPUT SUMMARY`**：返回差异摘要，替代
   完整差异行输出。证据：`diff_output_opt` 的 parser 规则 +
   `diff_9.sql` / `diff_11.sql` 中 `output summary` 的用例。

4. **Release Notes v26.3.0.10**：两个文档仓均已存在
   `Release-Notes/v26.3.0.10.md`，内容覆盖本次 tag 的用户可见变更
   （Data branch、SQL tasks & full-text、角色模型、统计/订阅、
   bugfix 分组）；无需本轮新增。

内部/跳过类（不写入 SQL Reference）：

- `data_branch_fullscan`：内部组件，无独立 SQL 入口。
- `sql_task` / `rewrite_rule`：本轮属于较大范围新特性，其语法面较广
  且部分细节需要产品同学复核（尤其 `CREATE TASK ... AS BEGIN ... END`
  的语义说明、`mo_task.sql_task` / `sql_task_run` 对外暴露程度、
  `enable_remap_hint` 与 `mo_role_rule` 是否作为公开 API）。为避免
  编造，不在 SQL Reference 中新增专页，仅在 Release Notes 中概述。
- 其他 bugfix / 内部优化：仅在 Release Notes 中列出。

## Repo: cn (matrixorigin/matrixorigin.io.cn) [push: ULookup/matrixorigin.io.cn]

### Docs Updated

- `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-cn.md`
  - 语法结构加入 `[COLUMNS (col_name [, col_name ...])]`
    与 `OUTPUT SUMMARY`。
  - 新增 `COLUMNS 列投影` 小节：列名大小写不敏感、去重，
    不影响 `OUTPUT COUNT|SUMMARY`。
  - 参数说明表追加 `COLUMNS (col_name, ...)` 与 `OUTPUT SUMMARY`
    两行。
  - 追加 `示例 9：列投影（COLUMNS）` 与
    `示例 10：差异摘要（OUTPUT SUMMARY）`，示例基于
    `diff_11.sql`。

### Docs Added

- `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick-cn.md`
  - 新增 `DATA BRANCH PICK` 专页，简体中文正文；SQL 关键字、参数、
    选项名保留英文原文。
  - 包含 语法说明 / 语法结构（KEYS、BETWEEN SNAPSHOT 两种形式 +
    可选 `WHEN CONFLICT`）/ 语法释义 / 使用说明（显式事务禁用、
    KEYS 或 BETWEEN SNAPSHOT 至少其一、BETWEEN 与源端快照互斥、
    目标侧快照不支持、子查询 KEYS 禁止 NULL、默认策略 FAIL）/ 5
    个示例 / 注意事项。
  - 示例严格基于 `pick_1.sql` / `pick_2.sql` / `pick_10.sql` /
    `pick_11.sql` 的测试用例。

### Navigation Updated

- `mkdocs.yml`：在 `Data Definition Language` 下紧随 `MERGE BRANCH`
  追加 `- PICK BRANCH: ...data-branch-pick-cn.md`，保持与
  Data Branch 家族相邻。

### Release Notes

- `docs/MatrixOne/Release-Notes/v26.3.0.10.md` 已存在（简体中文），
  内容涵盖数据分支、SQL 任务与全文检索、角色模型、统计/订阅、
  Bug 修复。mkdocs 版本目录已链接 `v26.3.0.10`。本轮无需新增。

### Skipped Changes

### Skipped: SQL Task 语句族（CREATE / ALTER / DROP / EXECUTE / SHOW TASK）

- Repo: cn
- Source files: 同 io 仓，参考上方 io Skipped Changes。
- Reason: 与 io 相同——语法面较广且部分细节（body 分隔符、
  `mo_task.sql_task*` 是否公开、cron 语义、权限与默认策略）需要
  产品/后端同学进一步确认，避免翻译时额外引入假设。Release Notes
  已收录 "SQL 任务流水线：实现端到端的 SQL 任务执行流水线（#24123）"
  作为兜底记录。
- Suggested human action: 与 io 仓同步新增 `CREATE TASK` 中文专页，
  放在 DDL 章节，与 `CREATE DYNAMIC TABLE` / `CREATE CDC` 相邻。

### Skipped: 角色重写规则（ALTER ROLE ADD/DROP RULE、SHOW RULES ON ROLE、enable_remap_hint）

- Repo: cn
- Source files: 同 io 仓。
- Reason: 与 io 相同——公开状态尚未确认，且涉及 `mo_role_rule` 系统
  表与 `enable_remap_hint` 会话变量的对外定位。Release Notes 已收
  "鉴权：新增角色规则能力（#23823）（#23851）"。
- Suggested human action: 确定对外语义后在 DCL 下新增专页，并补齐
  与 `GRANT` / `CREATE ROLE` 的导航联动。

### Risks

- DATA BRANCH PICK 新页示例使用到 `CREATE SNAPSHOT sp_from FOR
  ACCOUNT sys` 等跨账号操作，需要 sys 账号权限；审稿人请确认该
  示例在 cn 仓其他 DATA BRANCH 文档的示例风格下仍合适。
- `data-branch-diff-cn.md` 中 `OUTPUT SUMMARY` 返回格式同 io，
  未确定具体列布局；仅表述语义。
- 本轮未新增 `CREATE TASK`、`ALTER ROLE ... RULE` 等专页，存在
  文档覆盖率落后于实现的风险；Release Notes 已兜底。
