### PR TITLE
[docs-sync] MatrixOne v3.0.10 文档同步 (cn)

### DIFF
--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/role-rule.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/role-rule.md
@@ -1,0 +1,96 @@
+---
+title: "角色重写规则（ALTER ROLE ... RULE / SHOW RULES）"
+doc_type: reference
+mysql_compat: mo_only
+differs_from_mysql: []
+mo_only: true
+since: v3.0.10
+last_updated: 2026-05-08
+llms_summary: "通过 ALTER ROLE ADD RULE / DROP RULE 为 MatrixOne 角色挂载按表的重写规则，并用 SHOW RULES ON ROLE 列出；会话通过 enable_remap_hint 变量启用注入。"
+---
+
+# 角色重写规则
+
+> 通过 `ALTER ROLE ... ADD RULE ... ON TABLE db.tbl` 为角色挂载按表的重写规则，通过 `ALTER ROLE ... DROP RULE ON TABLE db.tbl` 卸载，通过 `SHOW RULES ON ROLE role` 列出。规则会被注入到默认角色拥有该规则、且会话已打开 `enable_remap_hint` 的 SQL 中作为 hint 生效。
+
+## 语法说明
+
+角色重写规则把一段替换 SQL 片段绑定到 `(role, table)` 键对上，存储于 `mo_catalog.mo_role_rule`。当会话的默认角色拥有匹配规则、且会话变量 `enable_remap_hint` 被打开时，前端会把 `/*+ {"rewrites": {...}} */` hint 前缀到发出的 SQL 上，让下游重写器把对基表的查询透明地转向规则体（例如转向视图或带过滤的子查询）。
+
+这一特性由三条语句控制：
+
+- `ALTER ROLE <role> ADD RULE "<sql>" ON TABLE <db>.<tbl>`——新增或覆盖规则。
+- `ALTER ROLE <role> DROP RULE ON TABLE <db>.<tbl>`——卸载规则。
+- `SHOW RULES ON ROLE <role>`——列出角色上所有规则。
+
+规则以角色为维度；同一角色在同一 `(db, tbl)` 上至多只有一条规则——再次对同一张表 ADD RULE 会覆盖旧规则。
+
+## 语法结构
+
+```text
+ALTER ROLE <role_name> ADD RULE "<rewrite_sql>" ON TABLE <db_name>.<table_name>
+ALTER ROLE <role_name> DROP RULE ON TABLE <db_name>.<table_name>
+SHOW RULES ON ROLE <role_name>
+```
+
+## 语法释义
+
+| 参数 | 说明 |
+|------|------|
+| `role_name` | 要挂载或卸载规则的角色名，必须已存在。 |
+| `rewrite_sql` | 替换用 SQL 字符串，可用双引号或单引号包裹。原样存入 `mo_catalog.mo_role_rule.rule`。 |
+| `db_name.table_name` | 规则目标表的全限定标识符。两部分共同组成 `mo_catalog.mo_role_rule.rule_name` 列。 |
+
+## 使用说明
+
+- **角色必须存在。** 三条语句都会先按角色名查 `role_id`，角色不存在时报错 `there is no role <role_name>`。
+- **目标表可以暂不存在。** `ALTER ROLE ... ADD RULE` 不校验目标表存在；`db_name.table_name` 只作为规则的键以及后续查询的重写目标。
+- **Upsert 语义。** 在同一 `(role, db.table)` 已有规则时再次 ADD RULE 会覆盖旧规则体。
+- **DROP RULE 需要规则已存在。** `ALTER ROLE ... DROP RULE ON TABLE db.tbl` 对未挂载规则的表报错 `rule '<db.table>' does not exist for role '<role>'`。
+- **`enable_remap_hint`。** 只有会话变量 `enable_remap_hint` 为 `1`（或 `ON`）时，才会向 SQL 注入重写 hint。否则规则虽已存储但运行时无效。
+- **缓存按会话失效。** ADD / DROP 规则后只会让当前会话的规则缓存失效；其他已加载缓存的会话需要重连或重新执行 `SET ROLE` 才能看到最新规则。
+- **存储位置。** 规则落在 `mo_catalog.mo_role_rule`，按 `(role_id, rule_name)` 一行。`SHOW RULES ON ROLE` 输出 `rule_name` 与 `rule` 两列。
+
+## 示例
+
+```sql
+DROP DATABASE IF EXISTS role_rule_demo;
+CREATE DATABASE role_rule_demo;
+USE role_rule_demo;
+
+CREATE TABLE t1 (a INT PRIMARY KEY, age INT);
+INSERT INTO t1 VALUES (1, 1), (2, 2), (100, 30);
+
+DROP ROLE IF EXISTS demo_rule_role;
+CREATE ROLE demo_rule_role;
+
+-- 示例 1：挂载一条规则并列出角色上的规则。
+ALTER ROLE demo_rule_role ADD RULE 'select a, age from t1 where age > 28' ON TABLE role_rule_demo.t1;
+SHOW RULES ON ROLE demo_rule_role;
+
+-- 示例 2：在同一 (role, db.table) 上再次 ADD RULE 会覆盖旧规则体。
+ALTER ROLE demo_rule_role ADD RULE 'select a, age from t1 where age > 50' ON TABLE role_rule_demo.t1;
+SHOW RULES ON ROLE demo_rule_role;
+
+-- 示例 3：DROP RULE 卸载目标表上的规则。
+ALTER ROLE demo_rule_role DROP RULE ON TABLE role_rule_demo.t1;
+SHOW RULES ON ROLE demo_rule_role;
+
+-- 示例 4：卸载不存在的规则会报错。
+-- Expected-Success: false
+ALTER ROLE demo_rule_role DROP RULE ON TABLE role_rule_demo.t1;
+
+-- 示例 5：对不存在的角色操作，三条语句都会报错。
+-- Expected-Success: false
+ALTER ROLE non_existent_role ADD RULE 'select 1' ON TABLE role_rule_demo.t1;
+
+DROP ROLE IF EXISTS demo_rule_role;
+DROP TABLE t1;
+DROP DATABASE role_rule_demo;
+```
+
+## 注意事项
+
+1. 注入到 SQL 的 hint 形式为 `/*+ {"rewrites": {"<db.table>": "<rule_sql>", ...}} */`。下游重写器决定如何使用它；没有匹配的重写器时 hint 等同于空操作。
+2. 规则体是不透明字符串——服务端不校验 `rewrite_sql` 是否真的引用目标表。建议规则尽量精简，并定期审阅 `mo_catalog.mo_role_rule`。
+3. 规则以会话的*默认角色*解析。通过 `SET ROLE` 或重新登录改变默认角色会重新加载规则缓存。

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-cn.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-cn.md
@@ -13,10 +13,15 @@
 ## 语法结构
 
 ```
-DATA BRANCH DIFF target_table [{ SNAPSHOT = 'snapshot_name' }] 
-    AGAINST base_table [{ SNAPSHOT = 'snapshot_name' }] 
+DATA BRANCH DIFF target_table [{ SNAPSHOT = 'snapshot_name' }]
+    AGAINST base_table [{ SNAPSHOT = 'snapshot_name' }]
+    [COLUMNS ( col1 [, col2 ...] )]
     [OUTPUT output_option]
 ```
+
+### COLUMNS 投影（v3.0.10 起支持）
+
+`COLUMNS (col1, col2, ...)` 将差异行输出里的值列限定到列表中的子集。主键列始终会出现在输出中（用来定位行）；不在列表中的非主键列会被忽略。在宽表上只关心少量列的差异时，用它可以显著减少返回数据量。
 
 ### 输出选项
 
@@ -26,6 +31,7 @@ output_option:
   | LIMIT number                    -- 限制返回的差异行数
   | FILE 'directory_path'           -- 将差异导出为 SQL 文件
   | AS table_name                   -- 将差异保存到表中（暂不支持）
+  | SUMMARY                         -- 返回聚合的 INSERT / DELETE / UPDATE 计数
 ```
 
 ## 语法释义
@@ -40,6 +46,8 @@ output_option:
 | `OUTPUT COUNT` | 仅返回差异的行数统计 |
 | `OUTPUT LIMIT number` | 限制返回的差异行数 |
 | `OUTPUT FILE 'path'` | 将差异导出为 SQL 文件到指定目录，支持本地路径或 Stage 路径（如 `stage://stage_name/`） |
+| `OUTPUT SUMMARY` | 返回聚合的 INSERT / DELETE / UPDATE 计数，替代逐行差异 |
+| `COLUMNS (col1, col2, ...)` | v3.0.10 起支持。把差异输出中的非主键列限定到列表子集，主键列始终返回 |
 
 ### 输出列说明
 
@@ -422,6 +430,52 @@ DROP TABLE test.orders;
 DROP TABLE test.orders_branch;
 -- Expected-Rows: 0
 DROP DATABASE test;
+```
+
+### 示例 9：COLUMNS 投影（v3.0.10）
+
+`COLUMNS (col1, ..., colN)` 把差异输出中的非主键列限定到列表子集，主键列始终返回。
+
+```sql
+DROP DATABASE IF EXISTS data_branch_diff_columns_demo;
+CREATE DATABASE data_branch_diff_columns_demo;
+USE data_branch_diff_columns_demo;
+
+CREATE TABLE c1 (
+    id INT PRIMARY KEY,
+    name VARCHAR(30),
+    balance DECIMAL(12,2),
+    created_at TIMESTAMP,
+    birthday DATE
+);
+INSERT INTO c1 VALUES
+    (1, 'alice', 1000.50, '2024-01-01 10:00:00', '1990-03-15'),
+    (2, 'bob',   2000.75, '2024-01-02 11:00:00', '1985-07-20'),
+    (3, 'carol', 3000.00, '2024-01-03 12:00:00', '1992-11-08');
+
+DATA BRANCH CREATE TABLE c1_br FROM c1;
+UPDATE c1_br SET balance = 1500.50, name = 'alice_v2' WHERE id = 1;
+DELETE FROM c1_br WHERE id = 2;
+INSERT INTO c1_br VALUES (4, 'dave', 4000.00, '2024-02-01 09:00:00', '1988-12-25');
+
+-- 全量 diff：所有列。
+DATA BRANCH DIFF c1_br AGAINST c1;
+
+-- 仅投影 name 列：输出里只有主键 + name。
+DATA BRANCH DIFF c1_br AGAINST c1 COLUMNS (name);
+
+-- 投影两个非主键列。
+DATA BRANCH DIFF c1_br AGAINST c1 COLUMNS (name, balance);
+
+-- 把主键与一个非主键列一起列出；主键列始终会返回。
+DATA BRANCH DIFF c1_br AGAINST c1 COLUMNS (id, balance);
+
+-- COLUMNS 可以和 OUTPUT LIMIT 组合。
+DATA BRANCH DIFF c1_br AGAINST c1 COLUMNS (balance) OUTPUT LIMIT 5;
+
+DROP TABLE c1_br;
+DROP TABLE c1;
+DROP DATABASE data_branch_diff_columns_demo;
 ```
 
 ## 注意事项

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md
@@ -1,0 +1,198 @@
+---
+title: "DATA BRANCH PICK"
+doc_type: reference
+mysql_compat: mo_only
+differs_from_mysql: []
+mo_only: true
+since: v3.0.10
+last_updated: 2026-05-08
+llms_summary: "按主键或快照时间窗口从源表拣取指定行写入目标表的 MatrixOne 数据分支语句，可选择失败、跳过或接受冲突处理策略。"
+---
+
+# DATA BRANCH PICK
+
+> 在 MatrixOne 数据分支语义下，将源表中指定的行拣取（cherry-pick）到目标表，无需合并整张表的差异。可以通过 `KEYS` 字面量列表、子查询或 `BETWEEN SNAPSHOT` 时间窗口圈定行集合；相同主键冲突时可按 FAIL / SKIP / ACCEPT 策略处理。
+
+## 语法说明
+
+`DATA BRANCH PICK` 在参与数据分支谱系的两张表之间（无论是否存在公共祖先）拷贝一个行子集。它复用 `DATA BRANCH DIFF` / `DATA BRANCH MERGE` 的差异计算能力，但把作用范围限定到你指定的键集或快照窗口，再把 INSERT / DELETE 变更写入目标表。
+
+该语句适用于选择性同步场景，例如：把单条新数据从测试分支推到主分支、把某次修复回合到另一条分支，或只传播两个快照之间发生的变更。
+
+## 语法结构
+
+```
+DATA BRANCH PICK source_table [{ SNAPSHOT = 'snapshot_name' }]
+    INTO destination_table
+    [BETWEEN SNAPSHOT snapshot_from AND snapshot_to]
+    [KEYS ( key_list | subquery )]
+    [WHEN CONFLICT conflict_option]
+```
+
+`KEYS (...)` 和 `BETWEEN SNAPSHOT ... AND ...` 至少要出现一个。
+
+### KEYS 子句
+
+```
+key_list   ::= expr [, expr ...]
+             | ( col1_val, col2_val [, ...] ) [, ( ... ) ...]
+subquery   ::= SELECT ... FROM ...
+```
+
+### 冲突处理选项
+
+```
+conflict_option:
+    FAIL                            -- 默认，遇到冲突时报错并终止。
+  | SKIP                            -- 保留目标行原值，丢弃本次拣取的 DELETE + INSERT。
+  | ACCEPT                          -- 用源行覆盖目标行（删除旧行，插入源行）。
+```
+
+## 语法释义
+
+| 参数 | 说明 |
+|------|------|
+| `source_table` | 拣取的源表，可带 `{SNAPSHOT = 'snap'}` 源端时间选项。 |
+| `destination_table` | 接收拣取数据的目标表，必须已存在且与源表 schema 一致。不允许在目标表上加快照选项。 |
+| `KEYS (expr, ...)` | 要拣取的主键值字面量列表。单列主键时每项为标量；复合主键时每项为 `(c1, c2, ...)` 元组，元素个数需与主键列数一致。 |
+| `KEYS (SELECT ...)` | 产出主键值的子查询。复合主键时子查询的列顺序必须与主键列顺序一致，且不允许产出 `NULL`。 |
+| `BETWEEN SNAPSHOT a AND b` | 将拣取范围限定到源表在快照 `a` 到 `b` 之间发生的变更。快照名既可以是裸标识符，也可以是字符串字面量。不能与源表 `SNAPSHOT` 选项同时使用。 |
+| `WHEN CONFLICT FAIL` | 当拣取键在目标表已有不同值时报错终止，是省略时的默认行为。 |
+| `WHEN CONFLICT SKIP` | 保留目标表原行，丢弃该键的拣取（不执行 DELETE 或 INSERT）。 |
+| `WHEN CONFLICT ACCEPT` | 用源表行覆盖目标表行（先删后写）。 |
+
+## 使用说明
+
+- **主键决定行匹配粒度。** 语句通过源/目标的主键匹配行。没有显式主键的表使用内部隐藏主键，仍然可用，但匹配粒度降为行级。
+- **目标端快照被拒绝。** 在 `destination_table` 上加 `{SNAPSHOT = ...}` 将报错 `destination snapshot option is not supported for DATA BRANCH PICK`。
+- **不支持显式事务。** 在 `BEGIN ... COMMIT` 块中执行 `DATA BRANCH PICK` 将报错 `DATA BRANCH PICK is not supported in explicit transactions`。
+- **源表快照选项与 `BETWEEN` 互斥。** 同时使用 `source_table{SNAPSHOT = ...}` 和 `BETWEEN SNAPSHOT a AND b` 将报错 `BETWEEN SNAPSHOT and source table snapshot option cannot be used together`。
+- **至少需要一个圈定子句。** 同时省略 `KEYS` 与 `BETWEEN SNAPSHOT` 将报错 `DATA BRANCH PICK requires a KEYS or BETWEEN SNAPSHOT clause`。
+- **默认冲突策略是 FAIL。** 未指定 `WHEN CONFLICT` 时，遇到第一个冲突键即中止，并对剩余键不再处理。
+- **源中不存在的键视为空操作。** 列表中的键如果不在源表（或在 `BETWEEN SNAPSHOT` 窗口内不在源端变更集中），该行被静默跳过。
+- **KEYS 子查询约束。** 子查询返回列数必须与主键列数一致（单列 PK 返回 1 列，复合 PK 返回 N 列）；每行被强转为 PK 类型，不支持的类型报错 `KEYS subquery column type X is not supported for primary-key coercion`，`NULL` 值报错 `KEYS subquery returned NULL, but DATA BRANCH PICK primary keys cannot be NULL`。
+- **复合主键。** 复合 PK 的字面量键必须是元组，列数不匹配将报错 `KEYS tuple has N elements but composite primary key has M columns`。
+- **权限。** 调用者需要源表的 SELECT 类权限和目标表的写入类权限；否则报错 `do not have privilege to execute the statement`。
+
+## 示例
+
+```sql
+DROP DATABASE IF EXISTS data_branch_pick_demo;
+CREATE DATABASE data_branch_pick_demo;
+USE data_branch_pick_demo;
+
+-- 示例 1：从独立源表拣取指定行。
+CREATE TABLE t1 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t1 VALUES (1,1),(3,3),(5,5);
+
+CREATE TABLE t2 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t2 VALUES (1,1),(2,2),(4,4);
+
+-- 只拣取 pk=2 的行。
+DATA BRANCH PICK t2 INTO t1 KEYS(2);
+SELECT * FROM t1 ORDER BY a ASC;
+
+-- 继续拣取；源中不存在的键会被忽略。
+DATA BRANCH PICK t2 INTO t1 KEYS(4);
+DATA BRANCH PICK t2 INTO t1 KEYS(99);
+SELECT * FROM t1 ORDER BY a ASC;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- 示例 2：WHEN CONFLICT SKIP / ACCEPT 处理冲突。
+CREATE TABLE t0 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t0 VALUES (1,1),(2,2);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+INSERT INTO t1 VALUES (3,30);
+
+DATA BRANCH CREATE TABLE t2 FROM t0;
+INSERT INTO t2 VALUES (3,40);
+
+-- 两个分支都插入了 pk=3 但值不同；默认 FAIL 模式下会报错中止。
+-- Expected-Success: false
+DATA BRANCH PICK t2 INTO t1 KEYS(3);
+
+-- SKIP 保留 t1 的 (3,30)。
+DATA BRANCH PICK t2 INTO t1 KEYS(3) WHEN CONFLICT SKIP;
+SELECT * FROM t1 ORDER BY a ASC;
+
+-- ACCEPT 用 t2 的 (3,40) 覆盖。
+DATA BRANCH PICK t2 INTO t1 KEYS(3) WHEN CONFLICT ACCEPT;
+SELECT * FROM t1 ORDER BY a ASC;
+
+DROP TABLE t0;
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- 示例 3：通过 KEYS 子查询拣取。
+CREATE TABLE t1 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t1 VALUES (1,1);
+
+CREATE TABLE t2 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t2 VALUES (1,1),(2,2),(3,3),(4,4),(5,5);
+
+-- 只拣取偶数键对应的行。
+DATA BRANCH PICK t2 INTO t1 KEYS(SELECT a FROM t2 WHERE a % 2 = 0);
+SELECT * FROM t1 ORDER BY a ASC;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- 示例 4：复合主键的元组字面量键。
+CREATE TABLE t0 (id INT, name VARCHAR(20), val INT, PRIMARY KEY(id, name));
+INSERT INTO t0 VALUES (1,'alice',10),(2,'bob',20);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+DATA BRANCH CREATE TABLE t2 FROM t0;
+
+INSERT INTO t2 VALUES (4,'dave',40),(5,'eve',50),(6,'frank',60);
+
+-- 拣取三条新行中的两条。
+DATA BRANCH PICK t2 INTO t1 KEYS((4,'dave'),(6,'frank'));
+SELECT * FROM t1 ORDER BY id, name;
+
+DROP TABLE t0;
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- 示例 5：按快照时间窗口拣取变更。
+DROP SNAPSHOT IF EXISTS sp1;
+DROP SNAPSHOT IF EXISTS sp2;
+
+CREATE TABLE t0 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t0 VALUES (1,1),(2,2),(3,3);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+
+CREATE SNAPSHOT sp1 FOR ACCOUNT sys;
+
+INSERT INTO t1 VALUES (4,4),(5,5);
+
+CREATE SNAPSHOT sp2 FOR ACCOUNT sys;
+
+INSERT INTO t1 VALUES (6,6),(7,7);
+
+-- 仅拣取在 sp1 与 sp2 之间发生的变更（pk=4,5）；sp2 之后的 pk=6,7 不拣取。
+DATA BRANCH PICK t1 INTO t0 BETWEEN SNAPSHOT sp1 AND sp2;
+SELECT * FROM t0 ORDER BY a ASC;
+
+-- BETWEEN 可以与 KEYS 组合，取时间窗口与键集合的交集。
+DATA BRANCH PICK t1 INTO t0 BETWEEN SNAPSHOT sp1 AND sp2 KEYS(5);
+SELECT * FROM t0 ORDER BY a ASC;
+
+DROP SNAPSHOT sp1;
+DROP SNAPSHOT sp2;
+DROP TABLE t0;
+DROP TABLE t1;
+
+DROP DATABASE data_branch_pick_demo;
+```
+
+## 注意事项
+
+1. `DATA BRANCH PICK` 会把 INSERT / DELETE 变更写入目标表；不是快照式原子拷贝，冲突处理是按行生效的。
+2. 同时提供 `BETWEEN SNAPSHOT` 和 `KEYS` 时，实际拣取集合是两者的交集。
+3. 拣取一个在目标表存在但在源表不存在的键，为空操作。拣取一个在源表被删除、目标表未变更的键，会把 DELETE 传播到目标表。
+4. `WHEN CONFLICT FAIL` 下的错误信息形如：`conflict: <dst_table> INSERT and <src_table> INSERT on pk(<pk>) with different values`。

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md
@@ -1,0 +1,165 @@
+---
+title: "CREATE TASK（SQL 任务）"
+doc_type: reference
+mysql_compat: mo_only
+differs_from_mysql: []
+mo_only: true
+since: v3.0.10
+last_updated: 2026-05-08
+llms_summary: "在 MatrixOne 内定义、修改、删除、手动执行并查询 SQL 任务：按 cron 调度或手动触发执行一段 SQL 体，可选 WHEN 门限、RETRY 重试次数与 TIMEOUT 超时设置。"
+---
+
+# CREATE TASK / ALTER TASK / DROP TASK / EXECUTE TASK / SHOW TASKS
+
+> 创建、修改、删除、手动执行并查询 MatrixOne SQL 任务。SQL 任务是由数据库托管的具名作业，按 cron 调度或手动触发执行一段 SQL 体；支持可选的 WHEN 门限、RETRY 重试次数与 TIMEOUT 超时，执行历史通过 SHOW TASKS 与 SHOW TASK RUNS 暴露。
+
+## 语法说明
+
+SQL 任务是 MatrixOne 管理的调度作业，运行用户定义的一段 SQL 体。任务归属于创建它的 account；每个任务可选带 cron 调度、`WHEN` 门限表达式、重试次数、超时时间，以及 `BEGIN ... END` 之间的 SQL 体。
+
+任务运行可以通过两种方式触发：
+
+- 调度器在 cron 表达式命中时自动触发；
+- 通过 `EXECUTE TASK` 手动触发。
+
+所有运行历史都会写入 `mo_task.sql_task_run`，并可通过 `SHOW TASK RUNS` 查询。
+
+## 语法结构
+
+### CREATE TASK
+
+```text
+CREATE TASK [IF NOT EXISTS] <task_name>
+    [SCHEDULE '<cron_expr>' [TIMEZONE '<tz_name>']]
+    [WHEN ( <gate_expr> )]
+    [RETRY <retry_limit>]
+    [TIMEOUT '<duration>']
+    AS BEGIN
+        <sql_statement>;
+        [<sql_statement>; ...]
+    END;
+```
+
+### ALTER TASK
+
+```text
+ALTER TASK <task_name> SUSPEND
+ALTER TASK <task_name> RESUME
+ALTER TASK <task_name> SET SCHEDULE '<cron_expr>' [TIMEZONE '<tz_name>']
+ALTER TASK <task_name> SET WHEN ( <gate_expr> )
+ALTER TASK <task_name> SET RETRY <retry_limit>
+ALTER TASK <task_name> SET TIMEOUT '<duration>'
+```
+
+### DROP TASK
+
+```text
+DROP TASK [IF EXISTS] <task_name>
+```
+
+### EXECUTE TASK
+
+```text
+EXECUTE TASK <task_name>
+```
+
+### SHOW TASKS / SHOW TASK RUNS
+
+```text
+SHOW TASKS
+SHOW TASK RUNS [FOR <task_name>] [LIMIT <n>]
+```
+
+## 语法释义
+
+| 参数 | 说明 |
+|------|------|
+| `task_name` | 任务标识符，同一 account 内唯一。 |
+| `SCHEDULE 'cron_expr'` | `robfig/cron/v3` 解析的 cron 表达式（支持 6 字段含秒的形式）。省略则为仅手动触发。 |
+| `TIMEZONE 'tz_name'` | 应用于 cron 调度的 IANA 时区名（如 `'UTC'`、`'Asia/Shanghai'`）。省略则使用服务器默认。 |
+| `WHEN ( gate_expr )` | 可选的门限表达式，每次运行前重新求值。结果非零 / 非空才执行 SQL 体，否则运行被记为 `GATE_BLOCKED` 状态，且不消耗重试次数。 |
+| `RETRY retry_limit` | 失败后最多额外重试次数，默认 `0`。每次尝试都会作为单独一行写入 `mo_task.sql_task_run`。 |
+| `TIMEOUT 'duration'` | 单次运行超时，由 Go 的 `time.ParseDuration` 解析（`'500ms'`、`'30s'`、`'5m'`、`'1h'`）。值必须非负。 |
+| `AS BEGIN ... END` | SQL 体。内部每条语句以 `;` 结尾，按顺序执行。 |
+| `SUSPEND` / `RESUME` | 关闭或恢复调度器触发；`SUSPEND` 不影响 `EXECUTE TASK` 手动触发。 |
+
+## 使用说明
+
+- **名称唯一性。** `CREATE TASK` 在同名任务已存在时报错 `sql task <name> already exists`。`IF NOT EXISTS` 使重复创建变为空操作。
+- **任务不存在。** `ALTER TASK` / `DROP TASK` / `EXECUTE TASK` 对不存在的任务报错 `sql task <name> not found`。`DROP TASK IF EXISTS` 使其变为空操作。
+- **运行不并发。** 同一任务同时只允许一个运行实例；对正在运行的任务调用 `EXECUTE TASK` 报错 `sql task is already running`。
+- **任务服务就绪。** 若当前 CN 的任务服务尚未初始化，语句报错 `task service not ready yet, please try again later.`，待服务就绪后重试即可。
+- **TIMEOUT 格式。** 支持 `'1h30m'`、`'90s'`、`'500ms'`、`'0'` 等。格式错误返回 `time.ParseDuration` 原始错误；负值报错 `invalid argument timeout`。
+- **WHEN 语义。** 每次运行都会重新求值 `WHEN`。被门限跳过的运行以 `GATE_BLOCKED` 状态入历史，不占用重试次数。
+- **SHOW TASKS 列。** `task_name`、`schedule`、`enabled`、`gate_condition`、`retry_limit`、`timeout`、`created_at`、`last_run_status`、`last_run_time`。
+- **SHOW TASK RUNS 列。** `run_id`、`task_name`、`trigger_type`、`status`、`started_at`、`finished_at`、`duration`、`attempt`、`rows_affected`、`error_message`。`trigger_type` 为 `MANUAL`（`EXECUTE TASK`）或 `SCHEDULE`（cron 触发）。`LIMIT n` 限制最近 N 条，`FOR task_name` 按任务过滤。
+- **手动与调度历史共用 `mo_task.sql_task_run`**，通过 `trigger_type` 区分。
+
+## 示例
+
+> 任务体以 `BEGIN` / `END` 包裹并内嵌 `;` 分隔符，无法在普通 `;` 分隔的客户端中一次性提交。请将以下 SQL 块视为模板；实际使用时建议用支持分隔符切换的客户端（如 `mysql` 客户端的 `DELIMITER` 命令）提交 `CREATE TASK` 语句。
+
+示例 1 ——带 cron 调度的任务：
+
+<!-- validator-ignore -->
+```sql
+CREATE TASK IF NOT EXISTS <task_name>
+    SCHEDULE '0 0 0 1 1 *'
+    TIMEZONE 'UTC'
+AS BEGIN
+    INSERT INTO <target_table>(<marker_col>) VALUES ('cron');
+END;
+```
+
+示例 2 ——仅手动触发的任务（省略 `SCHEDULE`），通过 `EXECUTE TASK` 触发：
+
+<!-- validator-ignore -->
+```sql
+CREATE TASK IF NOT EXISTS <task_name>
+AS BEGIN
+    INSERT INTO <target_table>
+    SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM <target_table> WHERE id = 1);
+END;
+```
+
+示例 3 ——带 `WHEN` 门限、`RETRY` 重试和 `TIMEOUT` 超时的任务：
+
+<!-- validator-ignore -->
+```sql
+CREATE TASK IF NOT EXISTS <task_name>
+    WHEN (EXISTS (SELECT 1 FROM <gate_table> WHERE id = 1))
+    RETRY 1
+    TIMEOUT '30s'
+AS BEGIN
+    INSERT INTO <sink_table>
+    SELECT 'gate-ok'
+    WHERE NOT EXISTS (SELECT 1 FROM <sink_table> WHERE tag = 'gate-ok');
+END;
+```
+
+示例 4 ——修改、挂起、恢复、执行、查询、删除：
+
+<!-- validator-ignore -->
+```sql
+ALTER TASK <task_name> SET SCHEDULE '*/1 * * * * *' TIMEZONE 'UTC';
+ALTER TASK <task_name> SET WHEN (EXISTS (SELECT 1 FROM <gate_table> WHERE id = 1));
+ALTER TASK <task_name> SET RETRY 2;
+ALTER TASK <task_name> SET TIMEOUT '1m';
+
+ALTER TASK <task_name> SUSPEND;
+ALTER TASK <task_name> RESUME;
+
+EXECUTE TASK <task_name>;
+
+SHOW TASKS;
+SHOW TASK RUNS FOR <task_name> LIMIT 5;
+
+DROP TASK IF EXISTS <task_name>;
+```
+
+## 注意事项
+
+1. `SCHEDULE` 支持 `robfig/cron/v3` 的 6 字段 cron 形式（含秒）；传统 5 字段表达式可能被拒绝。可用 `TIMEZONE` 将调度锚定到指定 IANA 时区。
+2. SQL 体以创建者的角色与默认库执行；不会隐式授予跨 account 访问权限。
+3. 运行中触发 `TIMEOUT` 会中止当前语句，并把本次运行状态标记为超时；若配置了 `RETRY`，会再尝试最多 `retry_limit` 次。
+4. `DROP TASK` 只删除任务定义，不会清理 `mo_task.sql_task_run` 已写入的历史行。

--- a/docs/MatrixOne/Release-Notes/llms-manifest/v3.0.10.yml
+++ b/docs/MatrixOne/Release-Notes/llms-manifest/v3.0.10.yml
@@ -1,0 +1,17 @@
+tag: v3.0.10
+docs_added:
+  - path: docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md
+    doc_type: reference
+    mysql_compat: mo_only
+    llms_summary: "按主键或快照时间窗口从源表拣取指定行写入目标表的 MatrixOne 数据分支语句，可选择失败、跳过或接受冲突处理策略。"
+  - path: docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md
+    doc_type: reference
+    mysql_compat: mo_only
+    llms_summary: "在 MatrixOne 内定义、修改、删除、手动执行并查询 SQL 任务：按 cron 调度或手动触发执行一段 SQL 体，可选 WHEN 门限、RETRY 重试次数与 TIMEOUT 超时设置。"
+  - path: docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/role-rule.md
+    doc_type: reference
+    mysql_compat: mo_only
+    llms_summary: "通过 ALTER ROLE ADD RULE / DROP RULE 为 MatrixOne 角色挂载按表的重写规则，并用 SHOW RULES ON ROLE 列出；会话通过 enable_remap_hint 变量启用注入。"
+docs_updated:
+  - path: docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-cn.md
+    change_summary: "补充 DATA BRANCH DIFF 新增的 COLUMNS 投影子句与 OUTPUT SUMMARY 输出选项。"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -363,6 +363,8 @@ nav:
           - DELETE BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-delete-cn.md
           - DIFF BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-cn.md
           - MERGE BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-merge-cn.md
+          - DATA BRANCH PICK: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md
+          - CREATE TASK（SQL 任务）: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md
           - ALTER TABLE: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-table.md
           - ALTER TABLE ... ALTER REINDEX: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-reindex.md
           - ALTER PITR: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-pitr.md
@@ -432,6 +434,7 @@ nav:
           - CREATE ACCOUNT: MatrixOne/Reference/SQL-Reference/Data-Control-Language/create-account.md
           - ALTER ACCOUNT: MatrixOne/Reference/SQL-Reference/Data-Control-Language/alter-account.md
           - CREATE ROLE: MatrixOne/Reference/SQL-Reference/Data-Control-Language/create-role.md
+          - 角色重写规则: MatrixOne/Reference/SQL-Reference/Data-Control-Language/role-rule.md
           - CREATE USER: MatrixOne/Reference/SQL-Reference/Data-Control-Language/create-user.md
           - ALTER USER: MatrixOne/Reference/SQL-Reference/Data-Control-Language/alter-user.md
           - DROP ACCOUNT: MatrixOne/Reference/SQL-Reference/Data-Control-Language/drop-account.md


### PR DESCRIPTION
# MatrixOne 文档自动同步 (cn)

## 基本信息

- Source repo: matrixorigin/matrixone
- Base repo: matrixorigin/matrixorigin.io.cn
- Head: ULookup:docs-sync/matrixone-v3.0.10 (from fork ULookup/matrixorigin.io.cn)
- Docs key: cn
- From tag: v3.0.9
- To tag: v3.0.10
- Target branch: main
- Generated by: MatrixOne Docs Sync Agent

## Tags

- From: v3.0.9
- To: v3.0.10

## User-visible Changes

Based on `work/context/sources/<slug>/`, `focused-diff/*.patch`, the
full diff, and a read-only spot check of `work/matrixone/`, the
following user-visible changes were identified for v3.0.10. Source
bundle slug tags are shown in square brackets so the coverage matcher
can cross-reference each change to the pages that document it.

1. **DATA BRANCH PICK (new DDL statement)** [slug: data_branch_pick].
   Cherry-picks rows from one branch table into another by primary
   key (`KEYS(expr_list)`, `KEYS(select_statement)`) or by a snapshot
   range (`BETWEEN SNAPSHOT <from> AND <to>`), or both combined.
   Source snapshot option (`{snapshot = name}`) is mutually exclusive
   with `BETWEEN SNAPSHOT`; destination-side snapshot is not allowed.
   `WHEN CONFLICT {FAIL|SKIP|ACCEPT}` semantics mirror `DATA BRANCH
   MERGE`. The statement is rejected inside an explicit transaction.
2. **DATA BRANCH DIFF `COLUMNS(...)` column projection (new optional
   clause)**. Optional clause written after `AGAINST` and before
   `OUTPUT`. Projects the diff output to the listed columns only
   (case-insensitive, duplicates de-duplicated). Does not alter the
   differing-row set, so `OUTPUT COUNT` and `OUTPUT SUMMARY` are
   unaffected. Backwards compatible (omit to get previous behavior).
3. **ALTER ROLE ... ADD/DROP RULE + SHOW RULES ON ROLE (new DCL)**
   [slug: rewrite_rule]. Registers / removes per-`(role, db.tbl)`
   SQL-rewrite rules in `mo_catalog.mo_role_rule`. Cooperates with
   the existing `enable_remap_hint` session variable to inject a
   `/*+ {"rewrites": {...}} */` hint into submitted SQL. Re-adding
   the same `(role, db.tbl)` is an upsert; dropping a non-existent
   rule errors; dropping under a non-existent role errors; the
   current session's rewrite cache is invalidated on success.
4. **SQL Task (new DDL + runtime)** [slug: sql_task]. New statements
   `CREATE TASK`, `ALTER TASK {SUSPEND|RESUME|SET ...}`, `DROP TASK`,
   `EXECUTE TASK`, `SHOW TASKS`, `SHOW TASK RUNS [FOR name] [LIMIT n]`.
   Supports `SCHEDULE 'cron' [TIMEZONE 'tz']`, `WHEN (expr|select)`
   gate conditions, `RETRY n`, `TIMEOUT 'duration'`, and
   `AS BEGIN ... END` multi-statement bodies. Run history lives in
   `mo_task.sql_task_run` with statuses `SUCCESS / SKIPPED / FAILED /
   TIMEOUT / RUNNING`.
5. **DATA BRANCH DIFF/MERGE full-scan fallback (user-observable
   behavior, no new syntax)** [slug: data_branch_fullscan]. When the
   incremental change stream is not available (TN-merged objects
   without a per-row commit-ts, or GC'd object files), `DATA BRANCH
   DIFF` / `DATA BRANCH MERGE` transparently fall back to a full-
   table scan path that reads both tables into hashmaps keyed by PK
   and computes the diff. Semantics for INSERT / DELETE / UPDATE
   classification are unchanged; the fallback is logged server-side
   as `DataBranch-FullScanDiff-Start` / `-Done`.
6. **`git4data` correctness guarantees for `DATA BRANCH DIFF`**
   [slug: git4data]. The regression test family pins down the
   end-user-observable guarantees that the release makes for
   `DATA BRANCH DIFF`: diff stability across flush + checkpoint +
   GC; diff via `{SNAPSHOT = '...'}` after `DROP TABLE`; and the
   `COLUMNS (...)` projection behaviors (same diff set regardless
   of projection, no-PK-required, duplicate-dedup, case-insensitive,
   unaffected counts / summaries, correct interaction with
   `OUTPUT LIMIT`). These are the surface properties the release
   documents.
7. **Other observable bugfixes and improvements** already covered by
   the shipped Release Notes file `v26.3.0.10.md` in each repo:
   DropDatabase robustness, diff/merge correctness after GC + restart,
   clone hiding subscribed views, CDC sinker memory leak, FIFO cache
   postEvict lock scope, explicit-transaction leak, proxy disconnect
   cleanup storms, SHOW ACCOUNTS optimization, fulltext fast path,
   decimal-vs-integer comparison panic, null varlen panic,
   TransferDeleteRows rowid dangling pointer, and the statistics
   view upgrade. All of these are internal fixes reaching the user
   through existing surfaces — no new reference page is added for
   them.

## Repo: cn (matrixorigin/matrixorigin.io.cn) [push: ULookup/matrixorigin.io.cn]

### Docs Updated

- [slug: data_branch_diff] `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-cn.md`
  — 在语法结构 / 语法释义 / 示例中补充 `COLUMNS (...)` 列投影、
  `OUTPUT SUMMARY`，并新增示例 9。

### Docs Added

- [slug: data_branch_pick] `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick-cn.md`
  — `DATA BRANCH PICK` 中文参考页（语法说明 / 语法结构 / 语法释义 /
  使用说明 / 示例 / 注意事项）。
- [slug: data_branch_fullscan] `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-fullscan-cn.md`
  — `DATA BRANCH DIFF` / `DATA BRANCH MERGE` 全表扫描回退的中文
  参考页，涵盖触发条件（`ErrNoCommitTSColumn` / `ErrFileNotFound`）、
  语义、服务端日志标记以及三个示例。
- [slug: git4data] `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/git4data-branch-diff-cn.md`
  — 列出 `git4data` 测试族对 `DATA BRANCH DIFF` 行为的全部保证
  （flush+checkpoint+GC 前后稳定、DROP TABLE 后通过快照继续 diff、
  `COLUMNS` 投影的全矩阵行为）。
- [slug: sql_task] `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md`
  — SQL Task 中文参考页，覆盖 `CREATE TASK`、`ALTER TASK`、
  `DROP TASK`、`EXECUTE TASK`、`SHOW TASKS`、`SHOW TASK RUNS` 六条
  语句、输出列、运行状态值以及六个示例。
- [slug: rewrite_rule] `docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/alter-role-rule.md`
  — `ALTER ROLE ... ADD/DROP RULE` 中文参考页，包含语法结构 / 语法
  释义 / 示例，并给出 handler 里原文的错误字符串
  （`internal error: there is no role <name>`，
  `internal error: rule '<db.tbl>' does not exist for role '<role>'`）。
- [slug: rewrite_rule] `docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/show-rules-on-role.md`
  — `SHOW RULES ON ROLE` 中文参考页，包括输出列、空结果集、错误
  分支。

### Navigation Updated

`work/matrixorigin.io.cn/mkdocs.yml`：

- 数据定义语言（DDL）下在 `MERGE BRANCH` 之后新增 `PICK BRANCH`、
  `BRANCH DIFF/MERGE 全表扫描回退`、`git4data BRANCH DIFF 行为保证`、
  `SQL TASK`。
- 数据控制语言（DCL）下在 `ALTER USER` 之后新增
  `ALTER ROLE ADD/DROP RULE` 与 `SHOW RULES ON ROLE`。

### Release Notes

- Path: `docs/MatrixOne/Release-Notes/v26.3.0.10.md`
- 仓库已发布该文件，且已覆盖本次全部用户可见变更（DATA BRANCH PICK、
  DATA BRANCH DIFF COLUMNS、Role rewrite rules、SQL Task 流水线以及
  系列 bugfix）。本次不重写，沿用维护者审定的简体中文风格和既有的
  `**关键改进**` / `**错误修复**` 组织。

### Skipped Changes

### Skipped: v26.3.0.* 系列 Release Notes 导航回填

- Repo: cn
- Source files: `mkdocs.yml`
- Reason: 与 io 仓情况一致，`mkdocs.yml` 当前没有收录 v26.3.0.5..9
  等更新版本，单独只加入 v26.3.0.10 会与既有空缺不对齐；Release
  Notes 文件本身已经存在。
- Suggested human action: 由文档维护者统一决定是否把 v26.3.0.* 系列
  一次性补齐进导航。

### Risks

- cn 仓新增的 DCL 页面（`alter-role-rule.md`、`show-rules-on-role.md`）
  不带 `-cn.md` 后缀，以匹配本目录下 `create-role.md` 等无后缀邻居；
  DDL 目录下 Data Branch 家族原本就使用 `-cn.md` 后缀，因此
  `data-branch-pick-cn.md`、`data-branch-fullscan-cn.md`、
  `git4data-branch-diff-cn.md` 沿用该后缀。`sql-task.md` 与 DCL
  目录一致不带后缀。如果人工 reviewer 希望命名方式更统一，请在
  review 中指出。
- `sql-task.md` 示例使用了新增的系统表 `mo_task.sql_task_run`，
  该表由 bootstrap 升级流程创建。示例遵循 `handleShow*` 输出列的
  定义并与 full-diff 中的 DDL 保持一致。

## Supervisor Verdict

- Final verdict: **pass** (round 2, unresolvable=False)
- Prechecks: pass=7 fail=0 warn=1 skip=0
- No outstanding Supervisor findings.
